### PR TITLE
Make Builder Platform agnostic

### DIFF
--- a/cmd/seaweedfs-csi-driver/Dockerfile.dev
+++ b/cmd/seaweedfs-csi-driver/Dockerfile.dev
@@ -1,5 +1,4 @@
-FROM frolvlad/alpine-glibc as builder
-RUN apk add git go g++
+FROM golang:buster as builder
 
 RUN mkdir -p /go/src/github.com/chrislusf/
 RUN git clone https://github.com/chrislusf/seaweedfs /go/src/github.com/chrislusf/seaweedfs
@@ -8,7 +7,7 @@ RUN cd /go/src/github.com/chrislusf/seaweedfs/weed && go install
 FROM alpine AS final
 RUN apk add fuse
 LABEL author="Chris Lu"
-COPY --from=builder /root/go/bin/weed /usr/bin/
+COPY --from=builder /go/bin/weed /usr/bin/
 COPY ./_output/seaweedfs-csi-driver /seaweedfs-csi-driver
 
 RUN chmod +x /seaweedfs-csi-driver


### PR DESCRIPTION
This will use the official golang buster image which ships with a proper glib, go and git out of the box.  Also supports a broad range of platforms, enabling cross-arch builds with buildx later on.