### PR TITLE
Update CSI yaml to allow using k8s service DNS to contact the filer

### DIFF
--- a/deploy/kubernetes/seaweedfs-csi.yaml
+++ b/deploy/kubernetes/seaweedfs-csi.yaml
@@ -330,6 +330,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: csi-seaweedfs-node-sa
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.1
@@ -366,7 +367,7 @@ spec:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
             - name: SEAWEEDFS_FILER
-              value: "192.168.2.7:8888" # host and port of your SeaweedFs filer
+              value: "192.168.2.7:8888" # host and port of your SeaweedFs filer, could also be K8S DNS entry like seaweedfs-filer.seaweed-namespace.svc:8888
             - name: NODE_ID
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
I think lots of users are going to use the CSI driver with a seaweedfs cluster also running in k8s. The natural way to connect the driver to that cluster would be using DNS instead of hard coded IPs, so I set `SEAWEEDFS_FILER` to something like `seaweedfs-filer.seaweed-namespace.svc:8888`, which the driver kept timing out trying to connect. I realized the driver was running using `hostNetwork: true`, which means the in-cluster DNS resolution doesn't happen, so the .svc hostnames are just unresolved.

This changes the default YAML for the next person coming along to use the in-cluster DNS resolution first, and then the host's DNS resolution, so that if the filer happens to be running the cluster, it can be connected from the driver running on the host.

An alternative would be to not use `hostNetworking` for the driver daemonset, but I am presuming that's there for a reason.