### PR TITLE
Add map.uid and map.gid volume mount params via volume context

### DIFF
--- a/pkg/driver/mounter.go
+++ b/pkg/driver/mounter.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/chrislusf/seaweedfs/weed/glog"
 	"os/exec"
+
+	"github.com/chrislusf/seaweedfs/weed/glog"
 	"k8s.io/utils/mount"
 )
 
@@ -19,8 +20,8 @@ type Mounter interface {
 	Mount(target string) error
 }
 
-func newMounter(bucketName string, driver *SeaweedFsDriver) (Mounter, error) {
-	return newSeaweedFsMounter(bucketName, driver)
+func newMounter(bucketName string, driver *SeaweedFsDriver, volParameters map[string]string) (Mounter, error) {
+	return newSeaweedFsMounter(bucketName, driver, volParameters)
 }
 
 func fuseMount(path string, command string, args []string) error {

--- a/pkg/driver/mounter.go
+++ b/pkg/driver/mounter.go
@@ -20,8 +20,8 @@ type Mounter interface {
 	Mount(target string) error
 }
 
-func newMounter(bucketName string, driver *SeaweedFsDriver, volParameters map[string]string) (Mounter, error) {
-	return newSeaweedFsMounter(bucketName, driver, volParameters)
+func newMounter(bucketName string, driver *SeaweedFsDriver, volContext map[string]string) (Mounter, error) {
+	return newSeaweedFsMounter(bucketName, driver, volContext)
 }
 
 func fuseMount(path string, command string, args []string) error {

--- a/pkg/driver/mounter_seaweedfs.go
+++ b/pkg/driver/mounter_seaweedfs.go
@@ -26,7 +26,7 @@ func newSeaweedFsMounter(bucketName string, driver *SeaweedFsDriver, volParamete
 }
 
 func (seaweedFs *seaweedFsMounter) Mount(target string) error {
-	glog.V(0).Infof("mounting %s%s to %s", seaweedFs.driver.filer, seaweedFs.bucketName, target)
+	glog.V(0).Infof("mounting %s %s to %s", seaweedFs.driver.filer, seaweedFs.bucketName, target)
 
 	args := []string{
 		"mount",

--- a/pkg/driver/mounter_seaweedfs.go
+++ b/pkg/driver/mounter_seaweedfs.go
@@ -8,20 +8,20 @@ import (
 
 // Implements Mounter
 type seaweedFsMounter struct {
-	bucketName    string
-	driver        *SeaweedFsDriver
-	volParameters map[string]string
+	bucketName string
+	driver     *SeaweedFsDriver
+	volContext map[string]string
 }
 
 const (
 	seaweedFsCmd = "weed"
 )
 
-func newSeaweedFsMounter(bucketName string, driver *SeaweedFsDriver, volParameters map[string]string) (Mounter, error) {
+func newSeaweedFsMounter(bucketName string, driver *SeaweedFsDriver, volContext map[string]string) (Mounter, error) {
 	return &seaweedFsMounter{
-		bucketName:    bucketName,
-		driver:        driver,
-		volParameters: volParameters,
+		bucketName: bucketName,
+		driver:     driver,
+		volContext: volContext,
 	}, nil
 }
 
@@ -38,7 +38,7 @@ func (seaweedFs *seaweedFsMounter) Mount(target string) error {
 		fmt.Sprintf("-filer.path=/buckets/%s", seaweedFs.bucketName),
 	}
 
-	for arg, value := range seaweedFs.volParameters {
+	for arg, value := range seaweedFs.volContext {
 		switch arg {
 		case "map.uid":
 			args = append(args, fmt.Sprintf("-map.uid=%s", value))

--- a/pkg/driver/mounter_seaweedfs.go
+++ b/pkg/driver/mounter_seaweedfs.go
@@ -8,18 +8,20 @@ import (
 
 // Implements Mounter
 type seaweedFsMounter struct {
-	bucketName string
-	driver     *SeaweedFsDriver
+	bucketName    string
+	driver        *SeaweedFsDriver
+	volParameters map[string]string
 }
 
 const (
 	seaweedFsCmd = "weed"
 )
 
-func newSeaweedFsMounter(bucketName string, driver *SeaweedFsDriver) (Mounter, error) {
+func newSeaweedFsMounter(bucketName string, driver *SeaweedFsDriver, volParameters map[string]string) (Mounter, error) {
 	return &seaweedFsMounter{
-		bucketName: bucketName,
-		driver:   driver,
+		bucketName:    bucketName,
+		driver:        driver,
+		volParameters: volParameters,
 	}, nil
 }
 
@@ -35,6 +37,16 @@ func (seaweedFs *seaweedFsMounter) Mount(target string) error {
 		fmt.Sprintf("-filer=%s", seaweedFs.driver.filer),
 		fmt.Sprintf("-filer.path=/buckets/%s", seaweedFs.bucketName),
 	}
+
+	for arg, value := range seaweedFs.volParameters {
+		switch arg {
+		case "map.uid":
+			args = append(args, fmt.Sprintf("-map.uid=%s", value))
+		case "map.gid":
+			args = append(args, fmt.Sprintf("-map.gid=%s", value))
+		}
+	}
+
 	if seaweedFs.driver.ConcurrentWriters > 0 {
 		args = append(args, fmt.Sprintf("-concurrentWriters=%d", seaweedFs.driver.ConcurrentWriters))
 	}

--- a/pkg/driver/nodeserver.go
+++ b/pkg/driver/nodeserver.go
@@ -55,7 +55,7 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		mo = append(mo, "ro")
 	}
 
-	volParameters := req.GetVolumeContext()
+	volParameters := req.GetPublishContext()
 
 	mounter, err := newMounter(volumeID, ns.Driver, volParameters)
 	if err != nil {

--- a/pkg/driver/nodeserver.go
+++ b/pkg/driver/nodeserver.go
@@ -55,9 +55,9 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		mo = append(mo, "ro")
 	}
 
-	volParameters := req.GetVolumeContext()
+	volContext := req.GetVolumeContext()
 
-	mounter, err := newMounter(volumeID, ns.Driver, volParameters)
+	mounter, err := newMounter(volumeID, ns.Driver, volContext)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/driver/nodeserver.go
+++ b/pkg/driver/nodeserver.go
@@ -57,6 +57,8 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 
 	volParameters := req.GetPublishContext()
 
+	glog.V(0).Infof("Parameters: %s", volParameters)
+
 	mounter, err := newMounter(volumeID, ns.Driver, volParameters)
 	if err != nil {
 		return nil, err

--- a/pkg/driver/nodeserver.go
+++ b/pkg/driver/nodeserver.go
@@ -55,7 +55,9 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		mo = append(mo, "ro")
 	}
 
-	mounter, err := newMounter(volumeID, ns.Driver)
+	volParameters := req.GetVolumeContext()
+
+	mounter, err := newMounter(volumeID, ns.Driver, volParameters)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/driver/nodeserver.go
+++ b/pkg/driver/nodeserver.go
@@ -55,9 +55,7 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		mo = append(mo, "ro")
 	}
 
-	volParameters := req.GetPublishContext()
-
-	glog.V(0).Infof("Parameters: %s", volParameters)
+	volParameters := req.GetVolumeContext()
 
 	mounter, err := newMounter(volumeID, ns.Driver, volParameters)
 	if err != nil {


### PR DESCRIPTION
This PR adds the possibility to provide the `-map.uid` and `-map.gid` `weed mount` parameters to the CSI volume via `volume context`. Here's an example of a volume definition to Nomad CSI integration:

```
id = "mariadb"
name = "mariadb"
type = "csi"
plugin_id = "seaweedfs-csi-storage"
access_mode = "single-node-writer"
attachment_mode = "file-system"
context {
  "map.uid" = "999:0"
  "map.gid" = "999:0"
}
```

I've validated in my homelab this is working and I see the CSI plugin invoking `weed mount` with the new added `-map.uid` and `-map.gid` parameters on volume provisioning.