### PR TITLE
Remove extraneous parameters in Helm templates

### DIFF
--- a/deploy/helm/seaweedfs-csi-driver/templates/daemonset.yml
+++ b/deploy/helm/seaweedfs-csi-driver/templates/daemonset.yml
@@ -55,7 +55,6 @@ spec:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--filer=$(SEAWEEDFS_FILER)"
             - "--nodeid=$(NODE_ID)"
-            - "-v=9"
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock

--- a/deploy/helm/seaweedfs-csi-driver/templates/statefulset.yml
+++ b/deploy/helm/seaweedfs-csi-driver/templates/statefulset.yml
@@ -57,8 +57,6 @@ spec:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--filer=$(SEAWEEDFS_FILER)"
             - "--nodeid=$(NODE_ID)"
-            - -v
-            - "9"
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock


### PR DESCRIPTION
I just tried installing the seaweedfs-csi-driver via Helm.

Unfortunately it wasn't quite issue free. The  According to the logs there were unknown parameters given:
```
kubectl logs seaweedfs-csi-driver-node-rp5hh -c csi-seaweedfs-plugin
flag provided but not defined: -v
Usage of /seaweedfs-csi-driver:
  -cacheCapacityMB int
        local file chunk cache capacity in MB (0 will disable cache) (default 1000)
  -cacheDir string
        local cache directory for file chunks and meta data (default "/tmp")
  -concurrentWriters int
        limit concurrent goroutine writers if not 0 (default 32)
  -endpoint string
        CSI endpoint to accept gRPC calls (default "unix://tmp/seaweedfs-csi.sock")
  -filer string
        filer server (default "localhost:8888")
  -nodeid string
        node id
  -version
        Print the version and exit.
```

This pull requests removes them.
