### PR TITLE
CI: Add release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,105 @@
+name: Build & release Docker images
+
+on:
+  push:
+    branches:
+      - "**"
+    tags:
+      - 'v*'
+    paths:
+      - 'cmd/seaweedfs-csi-driver/Dockerfile'
+      - 'cmd/seaweedfs-csi-driver/*.go'
+      - 'pkg/driver/**'
+      - 'go.*'
+      - '.github/**'
+
+  # Build on PR
+  pull_request:
+
+  # Allow trigger for external PRs
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Fetch history
+        run: git fetch --prune --unshallow
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Get the current tag name
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Annotate Docker images
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: ${{ github.repository }}
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./cmd/seaweedfs-csi-driver/Dockerfile
+          platforms: linux/amd64
+          push: false
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          tags: ${{ github.repository }}:${{ env.RELEASE_VERSION }}
+
+      - name: Publish Docker image to DockerHub & GitHub Container Registry
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./cmd/seaweedfs-csi-driver/Dockerfile
+          platforms: linux/amd64
+          push: ${{ startsWith(github.ref, 'refs/tags/') }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          tags: |
+            ${{ github.repository }}:${{ env.RELEASE_VERSION }}
+            ghcr.io/${{ github.repository }}:${{ env.RELEASE_VERSION }}
+
+      - name: Update DockerHub repo description
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        uses: peter-evans/dockerhub-description@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          repository: ${{ github.repository }}
+
+      - name: Create Release
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ env.RELEASE_VERSION }}


### PR DESCRIPTION
These changes add a GitHub Actions release pipeline based on tags, [as outlined here](https://cmacr.ae/post/2021-07-09-a-simple-gh-actions-container-release-pipeline/).  

### Behaviour
- Build on all branches & PRs
- Build and release on tags starting with `v` (intended to be used with [Semantic Versioning](https://semver.org/))
- On release it will annotate the image with [OCI standards](https://github.com/opencontainers/image-spec/blob/master/annotations.md#pre-defined-annotation-keys), push to DockerHub & GitHub Container Registry, publish a GitHub release, sync the DockerHub repo README from the GitHub repo

### Example
To showcase this, here are some examples from my PR fork (will be removed if/when this PR is merged):
- [Non-release pipeline](https://github.com/cmacrae/seaweedfs-csi-driver/runs/3035386789?check_suite_focus=true)
- [Release pipeline](https://github.com/cmacrae/seaweedfs-csi-driver/runs/3035422258?check_suite_focus=true)
- [GitHub Release](https://github.com/cmacrae/seaweedfs-csi-driver/releases/tag/v0.1.0-example)
- [GHCR package](https://github.com/cmacrae/seaweedfs-csi-driver/pkgs/container/seaweedfs-csi-driver)
- [DockerHub repo](https://hub.docker.com/repository/docker/cmacrae/seaweedfs-csi-driver)
- Example of the Docker image annotations:
```
  org.opencontainers.image.title=seaweedfs-csi-driver
  org.opencontainers.image.description=SeaweedFS CSI Driver https://github.com/chrislusf/seaweedfs
  org.opencontainers.image.url=https://github.com/cmacrae/seaweedfs-csi-driver
  org.opencontainers.image.source=https://github.com/cmacrae/seaweedfs-csi-driver
  org.opencontainers.image.version=v0.1.0-example
  org.opencontainers.image.created=2021-07-10T09:43:28.359Z
  org.opencontainers.image.revision=0a69b20a0b559794c1969ac012c806cccc1e035a
  org.opencontainers.image.licenses=Apache-2.0
```

### Prerequisites


If you want to publish images to DockerHub, you'll need to define the following secrets in your GitHub repo's environment:  
- `DOCKERHUB_USERNAME`: Doesn't necessarily need to be a secret
- `DOCKERHUB_PASSWORD`: Yes, password I'm afraid. Necessary for the README syncing
- `DOCKERHUB_TOKEN`: For authenticating image pushes

If you want to publish images to GitHub Container Registry, you'll need the following secret:  
- `GHCR_TOKEN`: A personal access token with write:packages, read:user & user:email permissions

### Notes
Closes #17