### PR TITLE
Fix logging verbosity options

### DIFF
--- a/cmd/seaweedfs-csi-driver/main.go
+++ b/cmd/seaweedfs-csi-driver/main.go
@@ -1,12 +1,12 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"log"
 	"os"
 
 	"github.com/chrislusf/seaweedfs/weed/glog"
+	flag "github.com/chrislusf/seaweedfs/weed/util/fla9"
 	"github.com/seaweedfs/seaweedfs-csi-driver/pkg/driver"
 )
 

--- a/deploy/helm/seaweedfs-csi-driver/templates/daemonset.yml
+++ b/deploy/helm/seaweedfs-csi-driver/templates/daemonset.yml
@@ -55,6 +55,9 @@ spec:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--filer=$(SEAWEEDFS_FILER)"
             - "--nodeid=$(NODE_ID)"
+            {{- if .Values.logVerbosity }}
+            - "-v={{ .Values.logVerbosity }}"
+            {{- end }}
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock

--- a/deploy/helm/seaweedfs-csi-driver/templates/statefulset.yml
+++ b/deploy/helm/seaweedfs-csi-driver/templates/statefulset.yml
@@ -57,6 +57,9 @@ spec:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--filer=$(SEAWEEDFS_FILER)"
             - "--nodeid=$(NODE_ID)"
+            {{- if .Values.logVerbosity }}
+            - "-v={{ .Values.logVerbosity }}"
+            {{- end }}
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock

--- a/deploy/helm/seaweedfs-csi-driver/values.yaml
+++ b/deploy/helm/seaweedfs-csi-driver/values.yaml
@@ -4,6 +4,7 @@ seaweedfsFiler: ""
 storageClassName: seaweedfs-storage
 isDefaultStorageClass: false
 tlsSecret: ""
+#logVerbosity: 4
 
 imagePullPolicy: "IfNotPresent"
 


### PR DESCRIPTION
Currently seaweedfs csi driver is using usual flag library and forked version of glog, but forked version of glog is using forked version of flag. We need to use only one library for flags in order to be able to specify log verbosity options.