### PR TITLE
Allow static persistent volumes, some code cleanup

### DIFF
--- a/deploy/helm/seaweedfs-csi-driver/templates/storageclass.yml
+++ b/deploy/helm/seaweedfs-csi-driver/templates/storageclass.yml
@@ -1,10 +1,11 @@
+{{- if .Values.storageClassName }}
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: {{ .Values.storageClassName }}
-  namespace: {{ .Release.Namespace }}
   annotations:
     {{- if .Values.isDefaultStorageClass }}
     storageclass.kubernetes.io/is-default-class: "true"
     {{- end }}
 provisioner: {{ .Values.driverName }}
+{{- end }}

--- a/pkg/driver/controllerserver.go
+++ b/pkg/driver/controllerserver.go
@@ -39,16 +39,8 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	}
 
 	params := req.GetParameters()
-	glog.V(4).Info("params:%v", params)
+	glog.V(4).Infof("params:%v", params)
 	capacity := req.GetCapacityRange().GetRequiredBytes()
-	capacityGB := capacity >> 30
-	if capacityGB == 0 {
-		return nil, status.Error(codes.InvalidArgument, "required bytes less than 1GB")
-	}
-	seaweedFsVolumeCount := capacityGB / 30
-	if seaweedFsVolumeCount == 0 {
-		seaweedFsVolumeCount = 1
-	}
 
 	if err := filer_pb.Mkdir(cs.Driver, "/buckets", volumeId, nil); err != nil {
 		return nil, fmt.Errorf("Error setting bucket metadata: %v", err)
@@ -59,7 +51,7 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	return &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
 			VolumeId:      volumeId,
-			CapacityBytes: capacity, // 0, // seaweedFsVolumeCount * 1024 * 1024 * 30,
+			CapacityBytes: capacity,
 			VolumeContext: params,
 		},
 	}, nil

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -61,8 +61,6 @@ func NewSeaweedFsDriver(filer, nodeID, endpoint string) *SeaweedFsDriver {
 
 	n.AddVolumeCapabilityAccessModes([]csi.VolumeCapability_AccessMode_Mode{
 		csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-	})
-	n.AddVolumeCapabilityAccessModes([]csi.VolumeCapability_AccessMode_Mode{
 		csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
 	})
 	n.AddControllerServiceCapabilities([]csi.ControllerServiceCapability_RPC_Type{

--- a/pkg/driver/mounter.go
+++ b/pkg/driver/mounter.go
@@ -20,8 +20,8 @@ type Mounter interface {
 	Mount(target string) error
 }
 
-func newMounter(bucketName string, driver *SeaweedFsDriver, volContext map[string]string) (Mounter, error) {
-	return newSeaweedFsMounter(bucketName, driver, volContext)
+func newMounter(path string, collection string, readOnly bool, driver *SeaweedFsDriver, volContext map[string]string) (Mounter, error) {
+	return newSeaweedFsMounter(path, collection, readOnly, driver, volContext)
 }
 
 func fuseMount(path string, command string, args []string) error {

--- a/pkg/driver/nodeserver.go
+++ b/pkg/driver/nodeserver.go
@@ -2,6 +2,7 @@ package driver
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 
@@ -50,14 +51,19 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		return &csi.NodePublishVolumeResponse{}, nil
 	}
 
-	mo := req.GetVolumeCapability().GetMount().GetMountFlags()
-	if req.GetReadonly() {
-		mo = append(mo, "ro")
-	}
-
 	volContext := req.GetVolumeContext()
 
-	mounter, err := newMounter(volumeID, ns.Driver, volContext)
+	path, ok := volContext["path"]
+	if !ok {
+		path = fmt.Sprintf("/buckets/%s", volumeID)
+	}
+
+	collection, ok := volContext["collection"]
+	if !ok {
+		collection = volumeID
+	}
+
+	mounter, err := newMounter(path, collection, req.GetReadonly(), ns.Driver, volContext)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is cummulative PR. By default seaweedfs-csi-driver will dynamically create volume with unique collection id. But sometimes we need access to common distributed folder. This PR adds:

* StorageClass parameters:
  - collection - static collection id insteadof dynamic
  - replication - replace default replication value for this StorageClass
* Possibility to create static PersistentVolume objects:

```
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: seaweedfs-static
reclaimPolicy: Retain
provisioner: seaweedfs-csi-storage
```

```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: dfs-test
spec:
  storageClassName: seaweedfs-static
  volumeName: dfs-test
  accessModes:
  - ReadWriteMany
  resources:
    requests:
      storage: 1Gi
```

```
apiVersion: v1
kind: PersistentVolume
metadata:
  name: dfs-test
spec:
  accessModes:
  - ReadWriteMany
  capacity:
    storage: 1Gi
  csi:
    driver: seaweedfs-csi-driver
    volumeHandle: dfs-test
    volumeAttributes:
      collection: default
      path: /general/files
  persistentVolumeReclaimPolicy: Retain
  storageClassName: seaweedfs-static
```

Such volumes should have 'path' parameter which will be used as filer.path

Please note that all parameters from storage class (collection, replication) must be redefined in statically created PV.

* Honor read only parameter in request and pass it to `weed mount`
* StorgeClass object have no namespace and sometimes we don't need default StorageClass
* CapacityGB is not really used in controllerserver
* Calling `AddVolumeCapabilityAccessModes` multiple times makes no sense, cause subsequent call will override previous