### PR TITLE
use env to config log verbosity

### DIFF
--- a/deploy/helm/seaweedfs-csi-driver/templates/daemonset.yml
+++ b/deploy/helm/seaweedfs-csi-driver/templates/daemonset.yml
@@ -55,9 +55,6 @@ spec:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--filer=$(SEAWEEDFS_FILER)"
             - "--nodeid=$(NODE_ID)"
-            {{- if .Values.logVerbosity }}
-            - "-v={{ .Values.logVerbosity }}"
-            {{- end }}
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
@@ -74,6 +71,10 @@ spec:
               value: /var/run/secrets/app/tls/tls.crt
             - name: WEED_GRPC_CA
               value: /var/run/secrets/app/tls/ca.crt
+            {{- end }}
+            {{- if .Values.logVerbosity }}
+            - name: WEED_V
+              value: {{ .Values.logVerbosity | quote }}
             {{- end }}
           resources:
             {{ toYaml .Values.seaweedfsCsiPlugin.resources | nindent 12 }}

--- a/deploy/helm/seaweedfs-csi-driver/templates/statefulset.yml
+++ b/deploy/helm/seaweedfs-csi-driver/templates/statefulset.yml
@@ -57,9 +57,6 @@ spec:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--filer=$(SEAWEEDFS_FILER)"
             - "--nodeid=$(NODE_ID)"
-            {{- if .Values.logVerbosity }}
-            - "-v={{ .Values.logVerbosity }}"
-            {{- end }}
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
@@ -76,6 +73,10 @@ spec:
               value: /var/run/secrets/app/tls/tls.crt
             - name: WEED_GRPC_CA
               value: /var/run/secrets/app/tls/ca.crt
+            {{- end }}
+            {{- if .Values.logVerbosity }}
+            - name: WEED_V
+              value: {{ .Values.logVerbosity | quote }}
             {{- end }}
           volumeMounts:
             - name: socket-dir


### PR DESCRIPTION
### Problem

Current log verbosity configuration only applies to seaweedfs-csi-driver, not to weed mount process. Troubleshooting is not convenient when something goes wrong.

### Solution

Use environment variables to configure log verbosity.