### PR TITLE
Fix broken Helm template

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -2,7 +2,7 @@ name: dev Docker images
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
 
   # Build on PR
   pull_request:
@@ -69,3 +69,13 @@ jobs:
           platforms: linux/amd64, linux/arm, linux/arm64, linux/386
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
+  helm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Helm check
+        uses: igabaydulin/helm-check-action@0.1.4
+        env:
+          CHART_LOCATION: ./deploy/helm/seaweedfs-csi-driver
+          CHART_VALUES: ./deploy/helm/seaweedfs-csi-driver/values.yaml

--- a/deploy/helm/seaweedfs-csi-driver/values.yaml
+++ b/deploy/helm/seaweedfs-csi-driver/values.yaml
@@ -1,6 +1,5 @@
-
 # host and port of your SeaweedFs filer
-seaweedfsFiler: "SEAWEEDFS_FILER"
+seaweedfsFiler: "SEAWEEDFS_FILER:8888"
 storageClassName: seaweedfs-storage
 isDefaultStorageClass: false
 tlsSecret: ""
@@ -35,8 +34,8 @@ seaweedfsCsiPlugin:
 driverName: seaweedfs-csi-driver
 
 controller:
-  #affinity:
-  #tolerations:
+  affinity: {}
+  tolerations: {}
 
 node:
   # Deploy node daemonset
@@ -47,5 +46,5 @@ node:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 25%
-  #affinity:
-  #tolerations:
+  affinity: {}
+  tolerations: {}

--- a/deploy/kubernetes/seaweedfs-csi.yaml
+++ b/deploy/kubernetes/seaweedfs-csi.yaml
@@ -18,6 +18,7 @@ metadata:
   name: seaweedfs-storage
   annotations:
 provisioner: seaweedfs-csi-driver
+allowVolumeExpansion: true
 ---
 # Source: seaweedfs-csi-driver/templates/rbac.yml
 kind: ClusterRole
@@ -34,6 +35,9 @@ rules:
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [ "" ]
+    resources: [ "persistentvolumeclaims/status" ]
+    verbs: [ "get", "list", "watch", "update", "patch" ]
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
     verbs: ["get", "list", "watch"]
@@ -46,6 +50,9 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
     verbs: ["get", "list"]
+  - apiGroups: [ "" ]
+    resources: [ "pods" ]
+    verbs: [ "get", "list", "watch" ]
 ---
 # Source: seaweedfs-csi-driver/templates/rbac.yml
 kind: ClusterRole
@@ -263,7 +270,7 @@ spec:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
             - name: SEAWEEDFS_FILER
-              value: "SEAWEEDFS_FILER"
+              value: "SEAWEEDFS_FILER:8888"
             - name: NODE_ID
               valueFrom:
                 fieldRef:
@@ -349,6 +356,23 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+        # resizer
+        - name: csi-resizer
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+            - "--leader-election=false"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: IfNotPresent
+          resources:
+            
+            {}
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
         # SeaweedFs Plugin
         - name: seaweedfs-csi-plugin
           image: chrislusf/seaweedfs-csi-driver:latest
@@ -361,7 +385,7 @@ spec:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
             - name: SEAWEEDFS_FILER
-              value: "SEAWEEDFS_FILER"
+              value: "SEAWEEDFS_FILER:8888"
             - name: NODE_ID
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
`values.yaml` implicitly had `controller: nil` which caused templating to fail:

```
Error: template: seaweedfs-csi-driver/templates/statefulset.yml:19:22: executing "seaweedfs-csi-driver/templates/statefulset.yml" at <.Values.controller.affinity>: nil pointer evaluating interface {}.affinity
```

This PR
* fixes `helm template` by un-commenting the affinity lines (`controller: {}` would also work)
* adds a Github action to validate the template builds cleanly
* re-generates `deploy/kubernetes/seaweedfs-csi.yaml` with up-to-date values
* adds `:8888` to the `SEAWEEDFS_FILER` line to make it slightly clearer which port you probably want (I accidentally provided the 18888 port which broke things looking for 28888).

P.S. - Very cool project!