### PR TITLE
Fix error when managing multiple volumes

### DIFF
--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -30,8 +30,7 @@ type SeaweedFsDriver struct {
 	nodeID  string
 	version string
 
-	endpoint    string
-	mountSocket string
+	endpoint string
 
 	vcap  []*csi.VolumeCapability_AccessMode
 	cscap []*csi.ControllerServiceCapability
@@ -44,8 +43,6 @@ type SeaweedFsDriver struct {
 	CacheDir          string
 	UidMap            string
 	GidMap            string
-	Capacity          int64
-	DiskType          string
 }
 
 func NewSeaweedFsDriver(filer, nodeID, endpoint string) *SeaweedFsDriver {
@@ -54,12 +51,6 @@ func NewSeaweedFsDriver(filer, nodeID, endpoint string) *SeaweedFsDriver {
 
 	util.LoadConfiguration("security", false)
 
-	montDirHash := util.HashToInt32([]byte(endpoint))
-	if montDirHash < 0 {
-		montDirHash = -montDirHash
-	}
-	socket := fmt.Sprintf("/tmp/seaweedfs-mount-%d.sock", montDirHash)
-
 	n := &SeaweedFsDriver{
 		endpoint:       endpoint,
 		nodeID:         nodeID,
@@ -67,7 +58,6 @@ func NewSeaweedFsDriver(filer, nodeID, endpoint string) *SeaweedFsDriver {
 		version:        version,
 		filers:         pb.ServerAddresses(filer).ToAddresses(),
 		grpcDialOption: security.LoadClientTLS(util.GetViper(), "grpc.client"),
-		mountSocket:    socket,
 	}
 
 	n.AddVolumeCapabilityAccessModes([]csi.VolumeCapability_AccessMode_Mode{

--- a/pkg/driver/mounter.go
+++ b/pkg/driver/mounter.go
@@ -20,8 +20,18 @@ type Mounter interface {
 	Mount(target string) error
 }
 
-func newMounter(path string, collection string, readOnly bool, driver *SeaweedFsDriver, volContext map[string]string) (Mounter, error) {
-	return newSeaweedFsMounter(path, collection, readOnly, driver, volContext)
+func newMounter(volumeID string, readOnly bool, driver *SeaweedFsDriver, volContext map[string]string) (Mounter, error) {
+	path, ok := volContext["path"]
+	if !ok {
+		path = fmt.Sprintf("/buckets/%s", volumeID)
+	}
+
+	collection, ok := volContext["collection"]
+	if !ok {
+		collection = volumeID
+	}
+
+	return newSeaweedFsMounter(volumeID, path, collection, readOnly, driver, volContext)
 }
 
 func fuseMount(path string, command string, args []string) error {


### PR DESCRIPTION
# What problem are we solving?
When managing multiple volumes, we cannot record the volume context in the driver. This can lead to unintended consequences.
In addition, each mounted volume must use an independent local socket for management.

# How are we solving the problem?
- The volume context is only used during mounting and is not recorded in the driver.
- Each mounted volume uses an independent local socket for management.

# Unsolved Problem
**When multiple pods mount a same volume, the `weed mount` processes will use a same local socket.  If we expand the volume, only one process will be notified and change its quota.** 

https://github.com/garenchan/seaweedfs-csi-driver/blob/96d415ad3e121518552629f31a7cbe6eee9c76e4/pkg/driver/nodeserver.go#L149-L163

This problem can be a bit complicated to fix. My idea is that when multiple pods mount the same volume, we only need to run one `weed mount` process. And I'll try to make another PR to solve it.