### PR TITLE
Pods using the same volume share mount

### DIFF
--- a/deploy/helm/seaweedfs-csi-driver/templates/daemonset.yml
+++ b/deploy/helm/seaweedfs-csi-driver/templates/daemonset.yml
@@ -87,6 +87,9 @@ spec:
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi
+            - name: plugins-dir
+              mountPath: /var/lib/kubelet/plugins
+              mountPropagation: "Bidirectional"
             - name: pods-mount-dir
               mountPath: /var/lib/kubelet/pods
               mountPropagation: "Bidirectional"
@@ -105,6 +108,10 @@ spec:
           hostPath:
             path: /var/lib/kubelet/plugins/{{ .Values.driverName }}
             type: DirectoryOrCreate
+        - name: plugins-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins
+            type: Directory
         - name: pods-mount-dir
           hostPath:
             path: /var/lib/kubelet/pods

--- a/pkg/driver/controllerserver.go
+++ b/pkg/driver/controllerserver.go
@@ -11,11 +11,8 @@ import (
 
 	"github.com/chrislusf/seaweedfs/weed/glog"
 	"github.com/chrislusf/seaweedfs/weed/pb/filer_pb"
-	"github.com/chrislusf/seaweedfs/weed/pb/mount_pb"
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials/insecure"
 	_ "google.golang.org/grpc/resolver/passthrough"
 	"google.golang.org/grpc/status"
 )
@@ -175,25 +172,7 @@ func (cs *ControllerServer) ListSnapshots(ctx context.Context, req *csi.ListSnap
 }
 
 func (cs *ControllerServer) ControllerExpandVolume(ctx context.Context, req *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
-	volumeID := req.GetVolumeId()
-	glog.V(0).Infof("Controller expand volume %s to %d bytes", volumeID, req.CapacityRange.RequiredBytes)
-
-	localSocket := GetLocalSocket(volumeID)
-	clientConn, err := grpc.Dial("passthrough:///unix://"+localSocket, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		return nil, err
-	}
-	defer clientConn.Close()
-
-	client := mount_pb.NewSeaweedMountClient(clientConn)
-	_, err = client.Configure(context.Background(), &mount_pb.ConfigureRequest{
-		CollectionCapacity: req.CapacityRange.RequiredBytes,
-	})
-
-	return &csi.ControllerExpandVolumeResponse{
-		CapacityBytes: req.CapacityRange.RequiredBytes,
-	}, err
-
+	return nil, status.Error(codes.Unimplemented, "")
 }
 
 func (cs *ControllerServer) ControllerGetVolume(ctx context.Context, req *csi.ControllerGetVolumeRequest) (*csi.ControllerGetVolumeResponse, error) {

--- a/pkg/driver/volume.go
+++ b/pkg/driver/volume.go
@@ -1,0 +1,147 @@
+package driver
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/chrislusf/seaweedfs/weed/glog"
+	"github.com/chrislusf/seaweedfs/weed/pb/mount_pb"
+	"github.com/chrislusf/seaweedfs/weed/util"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+type Volume struct {
+	VolumeId string
+
+	// volume's real mount point
+	stagingTargetPath string
+
+	// Target paths to which the volume has been published.
+	// These paths are symbolic links to the real mount point.
+	// So multiple pods using the same volume can share a mount.
+	targetPaths map[string]bool
+
+	mounter Mounter
+
+	// unix socket used to manage volume
+	localSocket string
+}
+
+func NewVolume(volumeID string, mounter Mounter) *Volume {
+	return &Volume{
+		VolumeId:    volumeID,
+		mounter:     mounter,
+		targetPaths: make(map[string]bool),
+	}
+}
+
+func (vol *Volume) Stage(stagingTargetPath string) error {
+	if vol.isStaged() {
+		return nil
+	}
+
+	// check whether it can be mounted
+	if notMnt, err := checkMount(stagingTargetPath); err != nil {
+		return err
+	} else if !notMnt {
+		// maybe already mounted?
+		return nil
+	}
+
+	if err := vol.mounter.Mount(stagingTargetPath); err != nil {
+		return err
+	}
+
+	vol.stagingTargetPath = stagingTargetPath
+	return nil
+}
+
+func (vol *Volume) Publish(targetPath string) error {
+	if err := os.Remove(targetPath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	if err := os.Symlink(vol.stagingTargetPath, targetPath); err != nil {
+		return err
+	}
+
+	vol.targetPaths[targetPath] = true
+	return nil
+}
+
+func (vol *Volume) Expand(sizeByte int64) error {
+	if !vol.isStaged() {
+		return nil
+	}
+
+	target := fmt.Sprintf("passthrough:///unix://%s", vol.getLocalSocket())
+	dialOption := grpc.WithTransportCredentials(insecure.NewCredentials())
+
+	clientConn, err := grpc.Dial(target, dialOption)
+	if err != nil {
+		return err
+	}
+	defer clientConn.Close()
+
+	client := mount_pb.NewSeaweedMountClient(clientConn)
+	_, err = client.Configure(context.Background(), &mount_pb.ConfigureRequest{
+		CollectionCapacity: sizeByte,
+	})
+	return err
+}
+
+func (vol *Volume) Unpublish(targetPath string) error {
+	// Check whether the volume is published to the target path.
+	if _, ok := vol.targetPaths[targetPath]; !ok {
+		glog.Warningf("volume %s hasn't been published to %s", vol.VolumeId, targetPath)
+		return nil
+	}
+
+	delete(vol.targetPaths, targetPath)
+
+	if err := os.Remove(targetPath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	return nil
+}
+
+func (vol *Volume) Unstage(_ string) error {
+	if !vol.isStaged() {
+		return nil
+	}
+
+	mountPoint := vol.stagingTargetPath
+	glog.V(0).Infof("unmounting volume %s from %s", vol.VolumeId, mountPoint)
+
+	if err := fuseUnmount(mountPoint); err != nil {
+		return err
+	}
+
+	if err := os.Remove(mountPoint); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	return nil
+}
+
+func (vol *Volume) isStaged() bool {
+	return vol.stagingTargetPath != ""
+}
+
+func (vol *Volume) getLocalSocket() string {
+	if vol.localSocket != "" {
+		return vol.localSocket
+	}
+
+	montDirHash := util.HashToInt32([]byte(vol.VolumeId))
+	if montDirHash < 0 {
+		montDirHash = -montDirHash
+	}
+
+	socket := fmt.Sprintf("/tmp/seaweedfs-mount-%d.sock", montDirHash)
+	vol.localSocket = socket
+	return socket
+}


### PR DESCRIPTION
# What problem are we solving?
Even if multiple pods use the same volume, the driver will fork a child process for each of them to mount the volume. This is wasteful of resources and bad for management.

# How are we solving the problem?
The idea is that pods using the same volume need to share a `weed mount` child process.
We currently solve this problem based on the [CSI specification](https://github.com/container-storage-interface/spec/blob/master/spec.md). 

1. When a volume is first used on a node, `NodeStageVolume` will fork a child process to mount it to host's `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/<pvc>/globalmount` directory.
2.  Later when other pod uses the volume, `NodePublishVolume` just needs to create a symbolic link `/var/lib/kubelet/pods/<pod>/volumes/kubernetes.io~csi/<pvc>/mount` to the `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/<pvc>/globalmount` directory.
3. If the pod using the volume on the node is deleted, then `NodeUnpublishVolume` only needs to delete the corresponding symbolic link `/var/lib/kubelet/pods/<pod>/volumes/kubernetes.io~csi/<pvc>/mount`.
4. Finally, when the volume is not used by any pods on the node, `NodeUnstageVolume` will unmount the volume.

Additionally, according to the specification, we also consider scenarios for handling concurrent calls.
https://github.com/container-storage-interface/spec/blob/master/spec.md#concurrency

# Checks
- [x] I have tested the above scenarios if possible.