### PR TITLE
Fix error to avoid zombie processes

### DIFF
--- a/pkg/driver/mounter.go
+++ b/pkg/driver/mounter.go
@@ -44,6 +44,13 @@ func fuseMount(path string, command string, args []string) error {
 		return fmt.Errorf("Error fuseMount command: %s\nargs: %s\nerror: %v", command, args, err)
 	}
 
+	// avoid zombie processes
+	go func() {
+		if err := cmd.Wait(); err != nil {
+			glog.Errorf("weed mount process %d exit: %v", cmd.Process.Pid, err)
+		}
+	}()
+
 	return waitForMount(path, 10*time.Second)
 }
 

--- a/pkg/driver/volume.go
+++ b/pkg/driver/volume.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/chrislusf/seaweedfs/weed/glog"
 	"github.com/chrislusf/seaweedfs/weed/pb/mount_pb"
-	"github.com/chrislusf/seaweedfs/weed/util"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
@@ -136,12 +135,8 @@ func (vol *Volume) getLocalSocket() string {
 		return vol.localSocket
 	}
 
-	montDirHash := util.HashToInt32([]byte(vol.VolumeId))
-	if montDirHash < 0 {
-		montDirHash = -montDirHash
-	}
+	socket := GetLocalSocket(vol.VolumeId)
 
-	socket := fmt.Sprintf("/tmp/seaweedfs-mount-%d.sock", montDirHash)
 	vol.localSocket = socket
 	return socket
 }


### PR DESCRIPTION
# What problem are we solving?
Some zombie processes occur after unmounting volumes.

```
/ # ps -ef
PID   USER     TIME  COMMAND
    1 root      0:00 /seaweedfs-csi-driver --endpoint=unix:///csi/csi.sock --filer=192.168.1.100:8888 --nodeid=152-worker-0b2
   11 root      0:00 [weed]
   17 root      0:00 [weed]
   22 root      0:00 /bin/sh
```

# How are we solving the problem?
We should wait for `weed mount` child process to exit.

# Checks
- [x] I have tested the above scenarios if possible.