### PR TITLE
Fix #70: use bind mount rather than symbolic link

### DIFF
--- a/pkg/driver/nodeserver.go
+++ b/pkg/driver/nodeserver.go
@@ -111,7 +111,7 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 
 	// When pod uses a volume in read-only mode, k8s will automatically
 	// mount the volume as a read-only file system.
-	if err := volume.(*Volume).Publish(targetPath); err != nil {
+	if err := volume.(*Volume).Publish(targetPath, req.GetReadonly()); err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 


### PR DESCRIPTION
# What problem are we solving?
This may fix #70. But I'm not sure it's going to work.

# How are we solving the problem?
In k8s, the symbolic link of global mount point works well. But in nomad, I don't know why the container failed to mount symbolic link. Anyway,  a bind mount seems better than a symbolic link.
