### PR TITLE
Make sure mount points are cleaned up

### DIFF
--- a/pkg/driver/nodeserver.go
+++ b/pkg/driver/nodeserver.go
@@ -139,6 +139,11 @@ func (ns *NodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 	volume, ok := ns.volumes.Load(volumeID)
 	if !ok {
 		glog.Warningf("volume %s hasn't been published", volumeID)
+
+		// make sure there is no any garbage
+		mounter := mount.New("")
+		_ = mount.CleanupMountPoint(targetPath, mounter, true)
+
 		return &csi.NodeUnpublishVolumeResponse{}, nil
 	}
 
@@ -206,6 +211,11 @@ func (ns *NodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 	volume, ok := ns.volumes.Load(volumeID)
 	if !ok {
 		glog.Warningf("volume %s hasn't been staged", volumeID)
+
+		// make sure there is no any garbage
+		mounter := mount.New("")
+		_ = mount.CleanupMountPoint(stagingTargetPath, mounter, true)
+
 		return &csi.NodeUnstageVolumeResponse{}, nil
 	}
 


### PR DESCRIPTION
In some situations CSI driver may shutdown without cleaning up mount points (global or pod specific):
* on seaweedfs csi node update
* on seaweedfs fuse process crash

In such situation only whole node (server) reboot will help to recovery from error, cause manual restart of dependent pods will stuck - kubelet will complain that it is not able to delete stale mount point. Forcing mount points cleanup resolves problem.

Also map of targetPaths is not actual anymore, cause targetPath is a bind mount, not a symbolic link anymore.