### PR TITLE
Workaround link errors in CI until golang 1.20

### DIFF
--- a/cmd/seaweedfs-csi-driver/Dockerfile
+++ b/cmd/seaweedfs-csi-driver/Dockerfile
@@ -1,4 +1,6 @@
 FROM golang:1.19-alpine as builder
+# Can be removed at golang 1.20
+ENV CGO_CFLAGS=-fno-stack-protector
 
 RUN apk add git g++
 

--- a/cmd/seaweedfs-csi-driver/Dockerfile.dev
+++ b/cmd/seaweedfs-csi-driver/Dockerfile.dev
@@ -1,4 +1,6 @@
 FROM golang:1.19-alpine as builder
+# Can be removed at golang 1.20
+ENV CGO_CFLAGS=-fno-stack-protector
 RUN apk add git g++
 
 RUN mkdir -p /go/src/github.com/chrislusf/


### PR DESCRIPTION
Currently the github actions are broken due to a pending issue in golang 1.19 that will be fixed in golan 1.20, workaround is already available by overriding CGO_CFLAGS. See https://github.com/golang/go/issues/54313