### PR TITLE
Remove linux specific magic from fuse process start/stop.

### DIFF
--- a/pkg/driver/mount_util.go
+++ b/pkg/driver/mount_util.go
@@ -2,42 +2,10 @@ package driver
 
 import (
 	"errors"
-	"fmt"
-	"io/ioutil"
-	"os"
-	"strings"
-	"syscall"
 	"time"
 
-	"github.com/mitchellh/go-ps"
-	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"k8s.io/utils/mount"
 )
-
-func waitForProcess(p *os.Process, backoff int) error {
-	if backoff == 20 {
-		return fmt.Errorf("Timeout waiting for PID %v to end", p.Pid)
-	}
-	cmdLine, err := getCmdLine(p.Pid)
-	if err != nil {
-		glog.Warningf("Error checking cmdline of PID %v, assuming it is dead: %s", p.Pid, err)
-		return nil
-	}
-	if cmdLine == "" {
-		// ignore defunct processes
-		// TODO: debug why this happens in the first place
-		// seems to only happen on k8s, not on local docker
-		glog.Warning("Fuse process seems dead, returning")
-		return nil
-	}
-	if err := p.Signal(syscall.Signal(0)); err != nil {
-		glog.Warningf("Fuse process does not seem active or we are unprivileged: %s", err)
-		return nil
-	}
-	glog.Infof("Fuse process with PID %v still active, waiting...", p.Pid)
-	time.Sleep(time.Duration(backoff*100) * time.Millisecond)
-	return waitForProcess(p, backoff+1)
-}
 
 func waitForMount(path string, timeout time.Duration) error {
 	var elapsed time.Duration
@@ -56,32 +24,4 @@ func waitForMount(path string, timeout time.Duration) error {
 			return errors.New("Timeout waiting for mount")
 		}
 	}
-}
-
-func findFuseMountProcess(path string) (*os.Process, error) {
-	processes, err := ps.Processes()
-	if err != nil {
-		return nil, err
-	}
-	for _, p := range processes {
-		cmdLine, err := getCmdLine(p.Pid())
-		if err != nil {
-			glog.Errorf("Unable to get cmdline of PID %v: %s", p.Pid(), err)
-			continue
-		}
-		if strings.Contains(cmdLine, path) {
-			glog.Infof("Found matching pid %v on path %s", p.Pid(), path)
-			return os.FindProcess(p.Pid())
-		}
-	}
-	return nil, nil
-}
-
-func getCmdLine(pid int) (string, error) {
-	cmdLineFile := fmt.Sprintf("/proc/%v/cmdline", pid)
-	cmdLine, err := ioutil.ReadFile(cmdLineFile)
-	if err != nil {
-		return "", err
-	}
-	return string(cmdLine), nil
 }

--- a/pkg/driver/mounter_seaweedfs.go
+++ b/pkg/driver/mounter_seaweedfs.go
@@ -34,7 +34,7 @@ func newSeaweedFsMounter(volumeID string, path string, collection string, readOn
 	}, nil
 }
 
-func (seaweedFs *seaweedFsMounter) Mount(target string) (Mount, error) {
+func (seaweedFs *seaweedFsMounter) Mount(target string) (Unmounter, error) {
 	glog.V(0).Infof("mounting %v %s to %s", seaweedFs.driver.filers, seaweedFs.path, target)
 
 	var filers []string
@@ -91,11 +91,11 @@ func (seaweedFs *seaweedFsMounter) Mount(target string) (Mount, error) {
 		args = append(args, fmt.Sprintf("-map.gid=%s", seaweedFs.driver.GidMap))
 	}
 
-	m, err := newFuseMount(target, seaweedFsCmd, args)
+	u, err := fuseMount(target, seaweedFsCmd, args)
 	if err != nil {
 		glog.Errorf("mount %v %s to %s: %s", seaweedFs.driver.filers, seaweedFs.path, target, err)
 	}
-	return m, err
+	return u, err
 }
 
 func GetLocalSocket(volumeID string) string {

--- a/pkg/driver/mounter_seaweedfs.go
+++ b/pkg/driver/mounter_seaweedfs.go
@@ -34,7 +34,7 @@ func newSeaweedFsMounter(volumeID string, path string, collection string, readOn
 	}, nil
 }
 
-func (seaweedFs *seaweedFsMounter) Mount(target string) error {
+func (seaweedFs *seaweedFsMounter) Mount(target string) (Mount, error) {
 	glog.V(0).Infof("mounting %v %s to %s", seaweedFs.driver.filers, seaweedFs.path, target)
 
 	var filers []string
@@ -91,11 +91,11 @@ func (seaweedFs *seaweedFsMounter) Mount(target string) error {
 		args = append(args, fmt.Sprintf("-map.gid=%s", seaweedFs.driver.GidMap))
 	}
 
-	err := fuseMount(target, seaweedFsCmd, args)
+	m, err := newFuseMount(target, seaweedFsCmd, args)
 	if err != nil {
 		glog.Errorf("mount %v %s to %s: %s", seaweedFs.driver.filers, seaweedFs.path, target, err)
 	}
-	return err
+	return m, err
 }
 
 func GetLocalSocket(volumeID string) string {

--- a/pkg/driver/volume.go
+++ b/pkg/driver/volume.go
@@ -15,8 +15,8 @@ import (
 type Volume struct {
 	VolumeId string
 
-	mounter Mounter
-	mount   Mount
+	mounter   Mounter
+	unmounter Unmounter
 
 	// unix socket used to manage volume
 	localSocket string
@@ -39,8 +39,8 @@ func (vol *Volume) Stage(stagingTargetPath string) error {
 		_ = mount.New("").Unmount(stagingTargetPath)
 	}
 
-	if m, err := vol.mounter.Mount(stagingTargetPath); err == nil {
-		vol.mount = m
+	if u, err := vol.mounter.Mount(stagingTargetPath); err == nil {
+		vol.unmounter = u
 		return nil
 	} else {
 		return err
@@ -100,12 +100,12 @@ func (vol *Volume) Unpublish(targetPath string) error {
 func (vol *Volume) Unstage(stagingTargetPath string) error {
 	glog.V(0).Infof("unmounting volume %s from %s", vol.VolumeId, stagingTargetPath)
 
-	if vol.mount == nil {
+	if vol.unmounter == nil {
 		glog.Errorf("volume is not mounted: %s, path", vol.VolumeId, stagingTargetPath)
 		return nil
 	}
 
-	if err := vol.mount.Unmount(); err != nil {
+	if err := vol.unmounter.Unmount(); err != nil {
 		return err
 	}
 

--- a/pkg/driver/volume.go
+++ b/pkg/driver/volume.go
@@ -15,10 +15,8 @@ import (
 type Volume struct {
 	VolumeId string
 
-	// volume's real mount point
-	stagingTargetPath string
-
 	mounter Mounter
+	mount   Mount
 
 	// unix socket used to manage volume
 	localSocket string
@@ -26,33 +24,30 @@ type Volume struct {
 
 func NewVolume(volumeID string, mounter Mounter) *Volume {
 	return &Volume{
-		VolumeId: volumeID,
-		mounter:  mounter,
+		VolumeId:    volumeID,
+		mounter:     mounter,
+		localSocket: GetLocalSocket(volumeID),
 	}
 }
 
 func (vol *Volume) Stage(stagingTargetPath string) error {
-	if vol.isStaged() {
-		return nil
-	}
-
 	// check whether it can be mounted
 	if notMnt, err := checkMount(stagingTargetPath); err != nil {
 		return err
 	} else if !notMnt {
-		// maybe already mounted?
-		return nil
+		// try to unmount before mounting again
+		_ = mount.New("").Unmount(stagingTargetPath)
 	}
 
-	if err := vol.mounter.Mount(stagingTargetPath); err != nil {
+	if m, err := vol.mounter.Mount(stagingTargetPath); err == nil {
+		vol.mount = m
+		return nil
+	} else {
 		return err
 	}
-
-	vol.stagingTargetPath = stagingTargetPath
-	return nil
 }
 
-func (vol *Volume) Publish(targetPath string, readOnly bool) error {
+func (vol *Volume) Publish(stagingTargetPath string, targetPath string, readOnly bool) error {
 	// check whether it can be mounted
 	if notMnt, err := checkMount(targetPath); err != nil {
 		return err
@@ -68,7 +63,7 @@ func (vol *Volume) Publish(targetPath string, readOnly bool) error {
 	}
 
 	mounter := mount.New("")
-	if err := mounter.Mount(vol.stagingTargetPath, targetPath, "", mountOptions); err != nil {
+	if err := mounter.Mount(stagingTargetPath, targetPath, "", mountOptions); err != nil {
 		return err
 	}
 
@@ -76,11 +71,7 @@ func (vol *Volume) Publish(targetPath string, readOnly bool) error {
 }
 
 func (vol *Volume) Expand(sizeByte int64) error {
-	if !vol.isStaged() {
-		return nil
-	}
-
-	target := fmt.Sprintf("passthrough:///unix://%s", vol.getLocalSocket())
+	target := fmt.Sprintf("passthrough:///unix://%s", vol.localSocket)
 	dialOption := grpc.WithTransportCredentials(insecure.NewCredentials())
 
 	clientConn, err := grpc.Dial(target, dialOption)
@@ -106,36 +97,21 @@ func (vol *Volume) Unpublish(targetPath string) error {
 	return nil
 }
 
-func (vol *Volume) Unstage(_ string) error {
-	if !vol.isStaged() {
+func (vol *Volume) Unstage(stagingTargetPath string) error {
+	glog.V(0).Infof("unmounting volume %s from %s", vol.VolumeId, stagingTargetPath)
+
+	if vol.mount == nil {
+		glog.Errorf("volume is not mounted: %s, path", vol.VolumeId, stagingTargetPath)
 		return nil
 	}
 
-	mountPoint := vol.stagingTargetPath
-	glog.V(0).Infof("unmounting volume %s from %s", vol.VolumeId, mountPoint)
-
-	if err := fuseUnmount(mountPoint); err != nil {
+	if err := vol.mount.Unmount(); err != nil {
 		return err
 	}
 
-	if err := os.Remove(mountPoint); err != nil && !os.IsNotExist(err) {
+	if err := os.Remove(stagingTargetPath); err != nil && !os.IsNotExist(err) {
 		return err
 	}
 
 	return nil
-}
-
-func (vol *Volume) isStaged() bool {
-	return vol.stagingTargetPath != ""
-}
-
-func (vol *Volume) getLocalSocket() string {
-	if vol.localSocket != "" {
-		return vol.localSocket
-	}
-
-	socket := GetLocalSocket(vol.VolumeId)
-
-	vol.localSocket = socket
-	return socket
 }


### PR DESCRIPTION
Use pid from cmd.Process instead of /proc lookup
Use mount specific mutex
Log fuse mount process stderr and stdout for problems investigation
Proper fuse process shutdown on mount timeout

PR comments if any are really appreciated