### PR TITLE
Allow per pv/pvc settings for cache, concurrent writes and uid/gid maps

### DIFF
--- a/cmd/seaweedfs-csi-driver/main.go
+++ b/cmd/seaweedfs-csi-driver/main.go
@@ -16,7 +16,7 @@ var (
 	nodeID            = flag.String("nodeid", "", "node id")
 	version           = flag.Bool("version", false, "Print the version and exit.")
 	concurrentWriters = flag.Int("concurrentWriters", 32, "limit concurrent goroutine writers if not 0")
-	cacheSizeMB       = flag.Int64("cacheCapacityMB", 0, "local file chunk cache capacity in MB")
+	cacheSizeMB       = flag.Int("cacheCapacityMB", 0, "local file chunk cache capacity in MB")
 	cacheDir          = flag.String("cacheDir", os.TempDir(), "local cache directory for file chunks and meta data")
 	uidMap            = flag.String("map.uid", "", "map local uid to uid on filer, comma-separated <local_uid>:<filer_uid>")
 	gidMap            = flag.String("map.gid", "", "map local gid to gid on filer, comma-separated <local_gid>:<filer_gid>")

--- a/deploy/helm/seaweedfs-csi-driver/templates/daemonset.yml
+++ b/deploy/helm/seaweedfs-csi-driver/templates/daemonset.yml
@@ -61,6 +61,7 @@ spec:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--filer=$(SEAWEEDFS_FILER)"
             - "--nodeid=$(NODE_ID)"
+            - "--cacheDir=/var/cache/seaweedfs"
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
@@ -99,6 +100,8 @@ spec:
             - name: tls
               mountPath: /var/run/secrets/app/tls
             {{- end }}
+            - name: cache
+              mountPath: /var/cache/seaweedfs
       volumes:
         - name: registration-dir
           hostPath:
@@ -119,6 +122,8 @@ spec:
         - name: device-dir
           hostPath:
             path: /dev
+        - name: cache
+          emptyDir: {}
         {{- if .Values.tlsSecret }}
         - name: tls
           secret:

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -39,7 +39,7 @@ type SeaweedFsDriver struct {
 	filerIndex        int
 	grpcDialOption    grpc.DialOption
 	ConcurrentWriters int
-	CacheSizeMB       int64
+	CacheSizeMB       int
 	CacheDir          string
 	UidMap            string
 	GidMap            string


### PR DESCRIPTION
Currently cach size, concurrent writes and uid/gid maps can be set only globally for driver. This PR will allow to set them per pv/pvc.