### PR TITLE
Move securityContext into chart values with existing settings as default.

### DIFF
--- a/deploy/helm/seaweedfs-csi-driver/templates/daemonset.yml
+++ b/deploy/helm/seaweedfs-csi-driver/templates/daemonset.yml
@@ -51,13 +51,10 @@ spec:
               mountPath: /registration/
         - name: csi-seaweedfs-plugin
           securityContext:
-            privileged: true
-            capabilities:
-              add: ["SYS_ADMIN"]
-            allowPrivilegeEscalation: true
+            {{ toYaml .Values.seaweedfsCsiPlugin.securityContext | nindent 12 }}
           image: {{.Values.seaweedfsCsiPlugin.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-          args :
+          args:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--filer=$(SEAWEEDFS_FILER)"
             - "--nodeid=$(NODE_ID)"

--- a/deploy/helm/seaweedfs-csi-driver/values.yaml
+++ b/deploy/helm/seaweedfs-csi-driver/values.yaml
@@ -29,6 +29,11 @@ csiNodeDriverRegistrar:
 seaweedfsCsiPlugin:
   image: chrislusf/seaweedfs-csi-driver:latest
   resources: {}
+  securityContext:
+    privileged: true
+    capabilities:
+      add: ["SYS_ADMIN"]
+    allowPrivilegeEscalation: true
 
 # DO NOT Change. Reserved for future releases. Must be equal Name in GetPluginInfoResponse
 driverName: seaweedfs-csi-driver


### PR DESCRIPTION
I had to patch the chart for deploy because Talos won't bring the pod up with the SYS_ADMIN capability.

I haven't done much helm authoring and didn't look at any of the other resources to see if this change needs mirroring in other resources or it should be in a different helm value.