### PR TITLE
Do not define namespace in seaweedfs-csi.yaml

### DIFF
--- a/deploy/kubernetes/seaweedfs-csi.yaml
+++ b/deploy/kubernetes/seaweedfs-csi.yaml
@@ -144,7 +144,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: seaweedfs-controller-sa
-    namespace: default
 roleRef:
   kind: ClusterRole
   name: seaweedfs-provisioner-role
@@ -158,7 +157,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: seaweedfs-controller-sa
-    namespace: default
 roleRef:
   kind: ClusterRole
   name: seaweedfs-attacher-role
@@ -172,7 +170,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: seaweedfs-controller-sa
-    namespace: default
 roleRef:
   kind: ClusterRole
   name: seaweedfs-snapshotter-role
@@ -186,7 +183,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: seaweedfs-controller-sa
-    namespace: default
 roleRef:
   kind: ClusterRole
   name: seaweedfs-driver-registrar-controller-role
@@ -200,7 +196,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: seaweedfs-node-sa
-    namespace: default
 roleRef:
   kind: ClusterRole
   name: seaweedfs-driver-registrar-node-role


### PR DESCRIPTION
It causes many problems on deployment, I spent about an hour debugging why the controller can't list PVC/Storage classes.
ClusterRoleBinding should be created in the same namespace. If we specify one in yaml and decide to use `-n namespace` in kubectl command, it will not create them in the same ns.