### PR TITLE
Rewrite building mount-args to allow configuring any parameter

### DIFF
--- a/cmd/seaweedfs-csi-driver/main.go
+++ b/cmd/seaweedfs-csi-driver/main.go
@@ -16,7 +16,7 @@ var (
 	nodeID            = flag.String("nodeid", "", "node id")
 	version           = flag.Bool("version", false, "Print the version and exit.")
 	concurrentWriters = flag.Int("concurrentWriters", 32, "limit concurrent goroutine writers if not 0")
-	cacheSizeMB       = flag.Int("cacheCapacityMB", 0, "local file chunk cache capacity in MB")
+	cacheCapacityMB       = flag.Int("cacheCapacityMB", 0, "local file chunk cache capacity in MB")
 	cacheDir          = flag.String("cacheDir", os.TempDir(), "local cache directory for file chunks and meta data")
 	uidMap            = flag.String("map.uid", "", "map local uid to uid on filer, comma-separated <local_uid>:<filer_uid>")
 	gidMap            = flag.String("map.gid", "", "map local gid to gid on filer, comma-separated <local_gid>:<filer_gid>")
@@ -39,7 +39,7 @@ func main() {
 
 	drv := driver.NewSeaweedFsDriver(*filer, *nodeID, *endpoint)
 	drv.ConcurrentWriters = *concurrentWriters
-	drv.CacheSizeMB = *cacheSizeMB
+	drv.CacheCapacityMB = *cacheCapacityMB
 	drv.CacheDir = *cacheDir
 	drv.UidMap = *uidMap
 	drv.GidMap = *gidMap

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -39,7 +39,7 @@ type SeaweedFsDriver struct {
 	filerIndex        int
 	grpcDialOption    grpc.DialOption
 	ConcurrentWriters int
-	CacheSizeMB       int
+	CacheCapacityMB   int
 	CacheDir          string
 	UidMap            string
 	GidMap            string

--- a/pkg/driver/mounter_seaweedfs.go
+++ b/pkg/driver/mounter_seaweedfs.go
@@ -112,7 +112,9 @@ func (seaweedFs *seaweedFsMounter) Mount(target string) (Unmounter, error) {
 
 	// Convert Args-Map to args
 	for arg, value := range argsMap{
-		args = append(args, fmt.Sprintf("-%s=%s", arg, value))
+		if(value != ""){	// ignore empty values
+			args = append(args, fmt.Sprintf("-%s=%s", arg, value))
+		}
 	}
 
 	u, err := fuseMount(target, seaweedFsCmd, args)

--- a/pkg/driver/mounter_seaweedfs.go
+++ b/pkg/driver/mounter_seaweedfs.go
@@ -41,25 +41,6 @@ func newSeaweedFsMounter(volumeID string, path string, collection string, readOn
 	}, nil
 }
 
-func (seaweedFs *seaweedFsMounter) getOrDefaultContext(key string, defaultValue string) string {
-	v, ok := seaweedFs.volContext[key]
-	if ok {
-		return v
-	}
-	return defaultValue
-}
-
-func (seaweedFs *seaweedFsMounter) getOrDefaultContextInt(key string, defaultValue int) int {
-	v := seaweedFs.getOrDefaultContext(key, "")
-	if v != "" {
-		iv, err := strconv.Atoi(v)
-		if err == nil {
-			return iv
-		}
-	}
-	return defaultValue
-}
-
 func (seaweedFs *seaweedFsMounter) Mount(target string) (Unmounter, error) {
 	glog.V(0).Infof("mounting %v %s to %s", seaweedFs.driver.filers, seaweedFs.path, target)
 
@@ -68,55 +49,70 @@ func (seaweedFs *seaweedFsMounter) Mount(target string) (Unmounter, error) {
 		filers = append(filers, string(address))
 	}
 
+	// CacheDir should be always defined - we use temp dir in case it is not defined
+	// we need to use predictable cache path, because we need to clean it up on unstage
+	cacheDir := filepath.Join(seaweedFs.driver.CacheDir, seaweedFs.volumeID)
+
+	// Final args
 	args := []string{
 		"-logtostderr=true",
 		"mount",
 		"-dirAutoCreate=true",
 		"-umask=000",
 		fmt.Sprintf("-dir=%s", target),
-		fmt.Sprintf("-collection=%s", seaweedFs.collection),
-		fmt.Sprintf("-filer=%s", strings.Join(filers, ",")),
-		fmt.Sprintf("-filer.path=%s", seaweedFs.path),
-		fmt.Sprintf("-cacheCapacityMB=%d", seaweedFs.getOrDefaultContextInt("cacheSizeMB", seaweedFs.driver.CacheSizeMB)),
 		fmt.Sprintf("-localSocket=%s", GetLocalSocket(seaweedFs.volumeID)),
-	}
-
-	// came from https://github.com/seaweedfs/seaweedfs-csi-driver/pull/12
-	// preferring explicit settings
-	// keeping this for backward compatibility
-	for arg, value := range seaweedFs.volContext {
-		switch arg {
-		case "map.uid":
-			args = append(args, fmt.Sprintf("-map.uid=%s", value))
-		case "map.gid":
-			args = append(args, fmt.Sprintf("-map.gid=%s", value))
-		case "replication":
-			args = append(args, fmt.Sprintf("-replication=%s", value))
-		case "diskType":
-			args = append(args, fmt.Sprintf("-disk=%s", value))
-		case "volumeCapacity":
-			capacityMB := parseVolumeCapacity(value)
-			args = append(args, fmt.Sprintf("-collectionQuotaMB=%d", capacityMB))
-		}
+		fmt.Sprintf("-cacheDir=%s", cacheDir),
 	}
 
 	if seaweedFs.readOnly {
 		args = append(args, "-readOnly")
 	}
 
-	// CacheDir should be always defined - we use temp dir in case it is not defined
-	// we need to use predictable cache path, because we need to clean it up on unstage
-	cacheDir := filepath.Join(seaweedFs.driver.CacheDir, seaweedFs.volumeID)
-	args = append(args, fmt.Sprintf("-cacheDir=%s", cacheDir))
+	// Handle volumeCapacity from controllerserver.go:51
+	if value, ok := seaweedFs.volContext["volumeCapacity"]; ok{
+		capacityMB := parseVolumeCapacity(value)
+		args = append(args, fmt.Sprintf("-collectionQuotaMB=%d", capacityMB))
+	}
 
-	if cw := seaweedFs.getOrDefaultContextInt("concurrentWriters", seaweedFs.driver.ConcurrentWriters); cw > 0 {
-		args = append(args, fmt.Sprintf("-concurrentWriters=%d", cw))
+	// Initial values for override-able args
+	argsMap := map[string]string {
+		"collection": 			seaweedFs.collection,
+		"filer": 				strings.Join(filers, ","),
+		"filer.path":			seaweedFs.path,
+		"cacheCapacityMB":		fmt.Sprint(seaweedFs.driver.CacheSizeMB),
+		"concurrentWriters":	fmt.Sprint(seaweedFs.driver.ConcurrentWriters),
+		"map.uid":				seaweedFs.driver.UidMap,
+		"map.gid":				seaweedFs.driver.GidMap,
 	}
-	if uidMap := seaweedFs.getOrDefaultContext("uidMap", seaweedFs.driver.UidMap); uidMap != "" {
-		args = append(args, fmt.Sprintf("-map.uid=%s", uidMap))
+
+	// volContext-parameter -> mount-arg
+	parameterArgMap := map[string]string{
+		"uidMap":		"map.uid",
+		"gidMap":		"map.gid",
+		"filerPath":	"filer.path",
+		// volumeContext has "diskType", but mount-option is "disk", converting for backwards compatability
+		"diskType":		"disk",
 	}
-	if gidMap := seaweedFs.getOrDefaultContext("gidMap", seaweedFs.driver.GidMap); gidMap != "" {
-		args = append(args, fmt.Sprintf("-map.gid=%s", gidMap))
+
+	//	Merge volContext into argsMap with key-mapping
+	for arg, value := range seaweedFs.volContext {
+		if(arg == "volumeCapacity"){	// Ignore volumeCapacity, not the nicest solution like this :/
+			continue
+		}
+
+		// Check if key-mapping exists
+		newArg, ok := parameterArgMap[arg]
+		if(ok){
+			arg = newArg
+		}
+
+		// Write to args-map
+		argsMap[arg] = value
+	}
+
+	// Convert Args-Map to args
+	for arg, value := range argsMap{
+		args = append(args, fmt.Sprintf("-%s=%s", arg, value))
 	}
 
 	u, err := fuseMount(target, seaweedFsCmd, args)

--- a/pkg/driver/mounter_seaweedfs.go
+++ b/pkg/driver/mounter_seaweedfs.go
@@ -79,7 +79,7 @@ func (seaweedFs *seaweedFsMounter) Mount(target string) (Unmounter, error) {
 		"collection": 			seaweedFs.collection,
 		"filer": 				strings.Join(filers, ","),
 		"filer.path":			seaweedFs.path,
-		"cacheCapacityMB":		fmt.Sprint(seaweedFs.driver.CacheSizeMB),
+		"cacheCapacityMB":		fmt.Sprint(seaweedFs.driver.CacheCapacityMB),
 		"concurrentWriters":	fmt.Sprint(seaweedFs.driver.ConcurrentWriters),
 		"map.uid":				seaweedFs.driver.UidMap,
 		"map.gid":				seaweedFs.driver.GidMap,


### PR DESCRIPTION
I have rewritten how the mount-args are generated.
This allows setting and overriding many parameters on a per-StorageClass and per-Volume level.

But because there are no longer checks for parameters, it allows misconfiguration. With great freedom comes great responsibility.
I dont think this will be a big issue though.

I have tested the code on minikube and it seems to work fine.