### PR TITLE
DataLocality for initially auto-applying DataCenter mount-option

### DIFF
--- a/cmd/seaweedfs-csi-driver/main.go
+++ b/cmd/seaweedfs-csi-driver/main.go
@@ -79,8 +79,8 @@ func convertRequiredValues() error {
 }
 
 func checkPreconditions() error {
-	if(dataLocality != datalocality.None && *dataCenter == ""){
-		return fmt.Errorf("dataLocality set, but not all locality-definitions were set! ('dataCenter')")
+	if err := driver.CheckDataLocality(&dataLocality, dataCenter); err != nil {
+		return err
 	}
 
 	return nil

--- a/deploy/helm/seaweedfs-csi-driver/templates/daemonset.yml
+++ b/deploy/helm/seaweedfs-csi-driver/templates/daemonset.yml
@@ -82,7 +82,7 @@ spec:
               valueFrom:
                 fieldRef:
                   # Injected by ModRule 'inject-topology-labels'
-                  fieldPath: metadata.labels['{{ .Values.node.injectTopologyInfoFromNodeLabel.labels.dataCenter }}']
+                  fieldPath: metadata.labels['dataCenter']
             {{- end }}
             {{- if .Values.tlsSecret }}
             - name: WEED_GRPC_CLIENT_KEY

--- a/deploy/helm/seaweedfs-csi-driver/templates/daemonset.yml
+++ b/deploy/helm/seaweedfs-csi-driver/templates/daemonset.yml
@@ -14,6 +14,11 @@ spec:
     metadata:
       labels:
         app: {{ template "seaweedfs-csi-driver.name" . }}-node
+      {{- if .Values.node.injectTopologyInfoFromNodeLabel.enabled }}
+      annotations:
+        # Tell KubeMod to make node metadata available to pod ModRules.
+        ref.kubemod.io/inject-node-ref: "true"
+      {{- end }}
     spec:
       priorityClassName: system-node-critical
       serviceAccountName: {{ template "seaweedfs-csi-driver.name" . }}-node-sa

--- a/deploy/helm/seaweedfs-csi-driver/templates/daemonset.yml
+++ b/deploy/helm/seaweedfs-csi-driver/templates/daemonset.yml
@@ -60,6 +60,9 @@ spec:
             - "--nodeid=$(NODE_ID)"
             - "--cacheDir=/var/cache/seaweedfs"
             - "--dataLocality={{ .Values.dataLocality }}"
+            {{- if .Values.node.injectTopologyInfoFromNodeLabel.enabled }}
+            - "--dataCenter=$(DATACENTER)"
+            {{- end }}
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
@@ -69,6 +72,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            {{- if .Values.node.injectTopologyInfoFromNodeLabel.enabled }}
+            - name: DATACENTER
+              valueFrom:
+                fieldRef:
+                  # Injected by ModRule 'inject-topology-labels'
+                  fieldPath: metadata.labels['{{ .Values.node.injectTopologyInfoFromNodeLabel.labels.dataCenter }}']
+            {{- end }}
             {{- if .Values.tlsSecret }}
             - name: WEED_GRPC_CLIENT_KEY
               value: /var/run/secrets/app/tls/tls.key

--- a/deploy/helm/seaweedfs-csi-driver/templates/daemonset.yml
+++ b/deploy/helm/seaweedfs-csi-driver/templates/daemonset.yml
@@ -59,6 +59,7 @@ spec:
             - "--filer=$(SEAWEEDFS_FILER)"
             - "--nodeid=$(NODE_ID)"
             - "--cacheDir=/var/cache/seaweedfs"
+            - "--dataLocality={{ .Values.dataLocality }}"
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock

--- a/deploy/helm/seaweedfs-csi-driver/templates/kubemod_modrule.yml
+++ b/deploy/helm/seaweedfs-csi-driver/templates/kubemod_modrule.yml
@@ -1,0 +1,29 @@
+# Based on https://github.com/kubernetes/kubernetes/issues/40610#issuecomment-1364368282
+{{- if .Values.node.injectTopologyInfoFromNodeLabel.enabled }}
+apiVersion: api.kubemod.io/v1beta1
+kind: ModRule
+metadata:
+  name: inject-topology-labels
+  #namespace: kubemod-system
+spec:
+  type: Patch
+  targetNamespaceRegex: ".*"
+  admissionOperations:
+    - UPDATE
+
+  match:
+    # Match pods...
+    - select: '{{ template "seaweedfs-csi-driver.name" . }}-node'
+      matchValue: 'Pod'
+    # ...which have access to the node's manifest through the synthetic ref injected by KubeMod.
+    - select: '$.syntheticRefs.node.metadata.labels'
+
+  patch:
+    # Grab the node's region and zone and put them in the pod's corresponding labels.
+    - op: add
+      path: /metadata/labels/topology.kubernetes.io~1region
+      value: '"{{ index .Target.syntheticRefs.node.metadata.labels "topology.kubernetes.io/region"}}"'
+    - op: add
+      path: /metadata/labels/topology.kubernetes.io~1zone
+      value: '"{{ index .Target.syntheticRefs.node.metadata.labels "topology.kubernetes.io/zone"}}"'
+{{- end }}

--- a/deploy/helm/seaweedfs-csi-driver/templates/kubemod_modrule.yml
+++ b/deploy/helm/seaweedfs-csi-driver/templates/kubemod_modrule.yml
@@ -4,7 +4,6 @@ apiVersion: api.kubemod.io/v1beta1
 kind: ModRule
 metadata:
   name: inject-topology-labels
-  #namespace: kubemod-system
 spec:
   type: Patch
   targetNamespaceRegex: ".*"
@@ -13,17 +12,17 @@ spec:
 
   match:
     # Match pods...
-    - select: '{{ template "seaweedfs-csi-driver.name" . }}-node'
+    - select: '$.kind'
       matchValue: 'Pod'
+    # ... with label app = seaweedfs-csi-driver ...
+    - select: '$.metadata.labels.app'
+      matchValue: '{{ template "seaweedfs-csi-driver.name" . }}-node'
     # ...which have access to the node's manifest through the synthetic ref injected by KubeMod.
     - select: '$.syntheticRefs.node.metadata.labels'
 
   patch:
     # Grab the node's region and zone and put them in the pod's corresponding labels.
     - op: add
-      path: /metadata/labels/topology.kubernetes.io~1region
-      value: '"{{ index .Target.syntheticRefs.node.metadata.labels "topology.kubernetes.io/region"}}"'
-    - op: add
-      path: /metadata/labels/topology.kubernetes.io~1zone
-      value: '"{{ index .Target.syntheticRefs.node.metadata.labels "topology.kubernetes.io/zone"}}"'
+      path: /metadata/labels/dataCenter
+      value: '{{`{{`}} index .Target.syntheticRefs.node.metadata.labels "{{ .Values.node.injectTopologyInfoFromNodeLabel.labels.dataCenter }}" {{`}}`}}'
 {{- end }}

--- a/deploy/helm/seaweedfs-csi-driver/values.yaml
+++ b/deploy/helm/seaweedfs-csi-driver/values.yaml
@@ -60,6 +60,14 @@ node:
   affinity: {}
   tolerations: {}
 
+  # Auto-Inject Topology-Info from Kubernetes node-labels using KubeMod (https://github.com/kubemod/kubemod)
+  #  Necessary because DownwardAPI doesnt support passing node-labels (see: https://github.com/kubernetes/kubernetes/issues/40610)
+  # Requires KubeMod to be installed
+  injectTopologyInfoFromNodeLabel:
+    enabled: false
+    labels:
+      dataCenter: "topology.kubernetes.io/zone"
+
   ## Change if not using standard kubernetes deployments, like k0s
   volumes:
     registration_dir: /var/lib/kubelet/plugins_registry

--- a/deploy/helm/seaweedfs-csi-driver/values.yaml
+++ b/deploy/helm/seaweedfs-csi-driver/values.yaml
@@ -42,6 +42,12 @@ controller:
   affinity: {}
   tolerations: {}
 
+# DataLocality (inspired by Longhorn) allows instructing the storage-driver which volume-locations will be used or preferred in Pods to read & write.
+#  e.g. Allows Pods to write preferrably to its local dataCenter volume-servers
+# Requires Volume-Servers to be correctly labelled and matching Topology-Info to be passed into seaweedfs-csi-driver node
+# Example-Value: "write_preferlocaldc"
+dataLocality: "none"
+
 node:
   # Deploy node daemonset
   enabled: true

--- a/pkg/datalocality/mapping.go
+++ b/pkg/datalocality/mapping.go
@@ -1,0 +1,31 @@
+package datalocality
+
+import (
+	"strings"
+)
+
+type DataLocality uint
+
+const (
+	None				DataLocality = iota
+	Write_preferLocalDc
+)
+
+// DataLocality -> String
+var dataLocalityStringMap = []string {
+	"none",
+	"write_preferlocaldc",
+}
+func (d DataLocality) String() string {
+	return dataLocalityStringMap[d]
+}
+
+// String -> DataLocality
+var stringDataLocalityMap = map[string]DataLocality {
+	"none": None,
+	"write_preferlocaldc": Write_preferLocalDc,
+}
+func FromString(s string) (DataLocality, bool) {
+	value, ok := stringDataLocalityMap[strings.ToLower(s)]
+	return value, ok
+}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -10,6 +10,7 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/security"
 	"github.com/seaweedfs/seaweedfs/weed/util"
+	"github.com/seaweedfs/seaweedfs-csi-driver/pkg/datalocality"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -43,6 +44,8 @@ type SeaweedFsDriver struct {
 	CacheDir          string
 	UidMap            string
 	GidMap            string
+	DataCenter        string
+	DataLocality	  datalocality.DataLocality
 }
 
 func NewSeaweedFsDriver(filer, nodeID, endpoint string) *SeaweedFsDriver {

--- a/pkg/driver/mounter_seaweedfs.go
+++ b/pkg/driver/mounter_seaweedfs.go
@@ -94,11 +94,14 @@ func (seaweedFs *seaweedFsMounter) Mount(target string) (Unmounter, error) {
 		"diskType":		"disk",
 	}
 
+	// Fields supplied in context, but ignored because they are handled explicitly somewhere else
+	ignoreArgs := []string{
+		"volumeCapacity",
+	}
+
 	//	Merge volContext into argsMap with key-mapping
 	for arg, value := range seaweedFs.volContext {
-		if(arg == "volumeCapacity"){	// Ignore volumeCapacity, not the nicest solution like this :/
-			continue
-		}
+		if(in_arr(ignoreArgs, arg)){continue}
 
 		// Check if key-mapping exists
 		newArg, ok := parameterArgMap[arg]
@@ -152,4 +155,13 @@ func parseVolumeCapacity(volumeCapacity string) int64 {
 
 	capacityMB := capacity / 1024 / 1024
 	return capacityMB
+}
+
+func in_arr(arr []string, val string) bool {
+	for _, v := range arr {
+		if(val == v) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/driver/mounter_seaweedfs.go
+++ b/pkg/driver/mounter_seaweedfs.go
@@ -106,6 +106,9 @@ func (seaweedFs *seaweedFsMounter) Mount(target string) (Unmounter, error) {
 			dataLocality = dataLocalityRes
 		}
 	}
+	if err := CheckDataLocality(&dataLocality, &seaweedFs.driver.DataCenter); err != nil {
+		return nil, err
+	}
 	// Settings based on type
 	switch(dataLocality){
 	case datalocality.Write_preferLocalDc:

--- a/pkg/driver/mounter_seaweedfs.go
+++ b/pkg/driver/mounter_seaweedfs.go
@@ -112,7 +112,9 @@ func (seaweedFs *seaweedFsMounter) Mount(target string) (Unmounter, error) {
 
 	// Convert Args-Map to args
 	for arg, value := range argsMap{
-		args = append(args, fmt.Sprintf("-%s=%s", arg, value))
+		if(value != ""){	// ignore empty values
+			args = append(args, fmt.Sprintf("-%s=%s", arg, value))
+		}
 	}
 
 	u, err := fuseMount(target, seaweedFsCmd, args)

--- a/pkg/driver/utils.go
+++ b/pkg/driver/utils.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/seaweedfs/seaweedfs-csi-driver/pkg/datalocality"
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -120,4 +121,11 @@ func (km *KeyMutex) GetMutex(key string) *sync.Mutex {
 
 func (km *KeyMutex) RemoveMutex(key string) {
 	km.mutexes.Delete(key)
+}
+
+func CheckDataLocality(dataLocality *datalocality.DataLocality, dataCenter *string) error {
+	if(*dataLocality != datalocality.None && *dataCenter == ""){
+		return fmt.Errorf("dataLocality set, but not all locality-definitions were set")
+	}
+	return nil
 }


### PR DESCRIPTION
DataLocality (inspired by [Longhorn](https://longhorn.io/docs/latest/high-availability/data-locality/)) allows instructing the storage-driver which volume-locations will be used or preferred in Pods to read & write.

It auto-sets mount-options based on the location a pod is scheduled in and the locality-option wanted.
The option can be set and overridden in Deployment, StorageClass and PersistentVolume.

Currently only 2 options exist:
- `None` changes nothing and is the default
- `write_preferLocalDc` sets the `DataCenter`-mount-option to the current Node-DataCenter, making writes local and reads wherever the data is.

---

Unfortunately Kubernetes doesnt allow grabbing node-labels, which contain well-known region-labels, and setting them as environment-variables.
The DownwardAPI is very limited in that regard. (see [#40610](https://github.com/kubernetes/kubernetes/issues/40610))

Therefore i have modified the helm-chart to include a workaround using [KubeMod](https://github.com/kubemod/kubemod) based on [this comment](https://github.com/kubernetes/kubernetes/issues/40610#issuecomment-1364368282).
More explanations in `deploy/helm/seaweed-csi-driver/values.yml` in the key `node.injectTopologyInfoFromNodeLabel`

If this isnt wanted, feel free to remove it.