### PR TITLE
Use helm YAML from seaweedfs repo

### DIFF
--- a/.github/workflows/helm_ci.yaml
+++ b/.github/workflows/helm_ci.yaml
@@ -1,0 +1,51 @@
+name: "helm: lint and test charts"
+
+on:
+  push:
+    branches: [ master ]
+    paths: ['deploy/helm/seaweedfs-csi-driver/**']
+  pull_request:
+    branches: [ master ]
+    paths: ['deploy/helm/seaweedfs-csi-driver/**']
+
+permissions:
+  contents: read
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.10.0
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          check-latest: true
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.3.1
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --chart-dirs deploy/helm/seaweedfs-csi-driver/)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
+      - name: Run chart-testing (lint)
+        run: ct lint --all --validate-maintainers=false --chart-dirs deploy/helm/seaweedfs-csi-driver/
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.5.0
+
+      - name: Run chart-testing (install)
+        run: ct install --all --chart-dirs deploy/helm/seaweedfs-csi-driver/

--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -1,0 +1,22 @@
+name: "helm: publish charts"
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+  pages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Publish Helm charts
+        uses: stefanprodan/helm-gh-pages@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          charts_dir: deploy/helm/
+          target_dir: helm
+          branch: gh-pages

--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@
 
 ### Install
 
+#### Helm
+
+1. Add the helm repo;
+
+```sh
+helm repo add seaweedfs-csi-driver https://seaweedfs.github.io/seaweedfs-csi-driver/helm
+"seaweedfs-csi-driver" has been added to your repositories
+```
+
+2. Check versions by `helm repo update seaweedfs-csi-driver` and `helm search repo seaweedfs-csi-driver`
+
+#### Source
+
 1. Clone this repository 
 ```sh
 git clone https://github.com/seaweedfs/seaweedfs-csi-driver.git

--- a/deploy/helm/seaweedfs-csi-driver/Chart.yaml
+++ b/deploy/helm/seaweedfs-csi-driver/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: seaweedfs-csi-driver
-description: A Helm chart for Kubernetes
+description: A Helm chart for Kubernetes CSI backed by a SeaweedFS cluster
 type: application
 version: 0.1.3
 appVersion: latest


### PR DESCRIPTION
Publish the helm chart via github pages, with a simple CI lint of the chart on PR.

Thanks to @washcycle as I just lifted their seaweedfs at https://github.com/seaweedfs/seaweedfs/pull/4243

Updated the paths and tested on my fork so far as proving it works. You might want to update the Chart.yaml `appVersion: latest` to a number, not sure how you want to handle this.

Required setup by maintainer for gh-pages branch to exist before the release workflow can complete;

```sh
git switch --orphan gh-pages
git commit --allow-empty -m "Initial Commit for Helm Releases"
git push origin gh-pages
```


* [x]  Documented helm instructions
* [x]  Replaces PR #111 
* [ ]  Create gh-pages branch [maintainer/owner]