### PR TITLE
Avoid null set on optional cli dataLocality arg

### DIFF
--- a/deploy/helm/seaweedfs-csi-driver/templates/daemonset.yaml
+++ b/deploy/helm/seaweedfs-csi-driver/templates/daemonset.yaml
@@ -42,7 +42,9 @@ spec:
             - --nodeid=$(NODE_ID)
             - --driverName=$(DRIVER_NAME)
             - --cacheDir=/var/cache/seaweedfs
-            - --dataLocality={{ .Values.dataLocality }}
+            {{- if ne "none" .Values.dataLocality}}
+            - "--dataLocality={{ .Values.dataLocality }}"
+            {{- end }}
             {{- if .Values.node.injectTopologyInfoFromNodeLabel.enabled }}
             - --dataCenter=$(DATACENTER)
             {{- end }}


### PR DESCRIPTION
This is actually a change from `Date:   Tue May 9 15:11:51 2023` on top of v1.1.3 which I don't entirely recall but it would have stopped my csi deploy without it. 

So I don't know if its now been made redundant but at the time my "optional" dataLocality flag didn't like being `"none"` instead of actually being absent.

This PR could may need to be chucked out, or probably fix the `not "none"` string logic, I don't use helm much. 