### PR TITLE
add missing permissions on persistenvolumes

### DIFF
--- a/deploy/helm/seaweedfs-csi-driver/templates/rbac.yaml
+++ b/deploy/helm/seaweedfs-csi-driver/templates/rbac.yaml
@@ -169,6 +169,9 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch","update","patch"]
+
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
As the title implies, this PR brings permissions into registrar-node-role to 

["get", "list", "watch","update","patch"]

It shoud fix https://github.com/seaweedfs/seaweedfs-csi-driver/issues/152
