### PR TITLE
Use capacity of one byte as 'no quota'

### DIFF
--- a/pkg/driver/nodeserver.go
+++ b/pkg/driver/nodeserver.go
@@ -80,7 +80,10 @@ func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		}
 		return nil, status.Error(codes.Internal, err.Error())
 	}
-	//k8s api get Capacity
+
+	// In seaweedfs quota is not configured on seaweedfs servers.
+	// Quota is applied only per mount.
+	// Previously we used to cmdline parameter to apply it, but such way does not allow dynamic resizing.
 	if capacity, err := k8s.GetVolumeCapacity(volumeID); err == nil {
 		if err := volume.Quota(capacity); err != nil {
 			return nil, err

--- a/pkg/driver/volume.go
+++ b/pkg/driver/volume.go
@@ -90,6 +90,11 @@ func (vol *Volume) Quota(sizeByte int64) error {
 	}
 	defer clientConn.Close()
 
+	// We can't create PV of zero size, so we're using quota of 1 byte to define no quota.
+	if sizeByte == 1 {
+		sizeByte = 0
+	}
+
 	client := mount_pb.NewSeaweedMountClient(clientConn)
 	_, err = client.Configure(context.Background(), &mount_pb.ConfigureRequest{
 		CollectionCapacity: sizeByte,


### PR DESCRIPTION
Before transition to dynamic quota changes we had a choice to define no quota at all by creating static PV. Current implementation does not allow to set zero as capacity and as a result there is no way to setup no quota.

This PR brings some code comments and allows to use one-byte capacity as 'no quota'.