### PR TITLE
Update rbac.yaml for fix invalid yaml

### DIFF
--- a/deploy/helm/seaweedfs-csi-driver/templates/rbac.yaml
+++ b/deploy/helm/seaweedfs-csi-driver/templates/rbac.yaml
@@ -169,6 +169,7 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch","update","patch"]
 


### PR DESCRIPTION
The RBAC is missing one line. When using `kustomize`:

Error: map[string]interface {}(nil): yaml: unmarshal errors:
  line 19: mapping key "resources" already defined at line 17
  line 20: mapping key "verbs" already defined at line 18