### PR TITLE
Safer volume ID

### DIFF
--- a/cmd/seaweedfs-csi-driver/Dockerfile.dev
+++ b/cmd/seaweedfs-csi-driver/Dockerfile.dev
@@ -6,11 +6,15 @@ RUN mkdir -p /go/src/github.com/seaweedfs/
 RUN git clone https://github.com/seaweedfs/seaweedfs /go/src/github.com/seaweedfs/seaweedfs
 RUN cd /go/src/github.com/seaweedfs/seaweedfs/weed && go install
 
+WORKDIR /go/src/github.com/seaweedfs/seaweedfs-csi-driver
+COPY . .
+RUN cd /go/src/github.com/seaweedfs/seaweedfs-csi-driver && go build -ldflags="-s -w" -o /seaweedfs-csi-driver ./cmd/seaweedfs-csi-driver/main.go
+
 FROM alpine AS final
 RUN apk add fuse
 LABEL author="Chris Lu"
 COPY --from=builder /go/bin/weed /usr/bin/
-COPY ./_output/seaweedfs-csi-driver /seaweedfs-csi-driver
+COPY --from=builder /seaweedfs-csi-driver /
 
 RUN chmod +x /seaweedfs-csi-driver
 ENTRYPOINT ["/seaweedfs-csi-driver"]

--- a/deploy/nomad/example-seaweedfs-volume.hcl
+++ b/deploy/nomad/example-seaweedfs-volume.hcl
@@ -26,7 +26,15 @@ mount_options {
 
 parameters {
   # Available options: https://github.com/seaweedfs/seaweedfs-csi-driver/blob/master/pkg/driver/mounter_seaweedfs.go
+  # By default, collection is the `volume ID` returned from the Create Volume gRPC call. Nomad calls this the
+  # External ID of the volume. "example" here overrides that.
   collection = "example"
   replication = "000"
+  # By default, path is "/buckets/<volume ID>", where `volume ID` is the value returned from the Create Volume gRPC
+  # call that Nomad calls the External ID. Do not use relative paths (paths that start with something other than /)
+  # They will will not work properly.
+  # When `path` is outside of the default path - `/buckets/<volume ID>` - the default path bucket will still be
+  # created, but remain empty. Since capabilities checks are tied to the default path of the volume, they may not
+  # provide the expected results.
   path = "/buckets/example"
 }

--- a/deploy/nomad/example-seaweedfs-volume.hcl
+++ b/deploy/nomad/example-seaweedfs-volume.hcl
@@ -1,4 +1,10 @@
+# id - Nomad internal ID. It is not sent to the CSI plugin but is used by Nomad for `per_alloc`
+# volume configurations, etc.
 id        = "example-seaweedfs-volume"
+# name - the name sent to the CSI plugin as an idempotency key and suggested volume ID. The CSI
+# spec requires the calling Container Orchestrator to respect the actual volumeId returned by the
+# CSI plugin. Nomad does this, storing it as the volume's ExternalID and using it in subsequent
+# calls to the controller and node.
 name      = "example-seaweedfs-volume"
 type      = "csi"
 plugin_id = "seaweedfs"

--- a/pkg/driver/controllerserver.go
+++ b/pkg/driver/controllerserver.go
@@ -211,6 +211,8 @@ func sanitizeVolumeId(volumeId string) string {
 		io.WriteString(h, volumeId)
 		// hexidecimal encoding of sha1 is 40 characters long
 		hexhash := hex.EncodeToString(h.Sum(nil))
+		// Use only lowercase letters
+		volumeId = strings.ToLower(volumeId)
 		sanitized := unsafeVolumeIdChars.ReplaceAllString(volumeId, "-")
 		// 21 here is 62 - 40 characters for the hash - 1 more for the "-" we use join
 		// the sanitized ID to the hash


### PR DESCRIPTION
This gave me fits attempting to get SeaweedFS and `seaweedfs-csi-driver` working with Nomad. There are some unclear naming challenges when working with Nomad, CSI, and SeaweedFS. Unfortunately, those naming collisions get even more painful when the CSI plugin creates a bucket with a name that SeaweedFS considers invalid because it used `name` from the Create Volume GRPC call directly and it turned out to be unsafe. Seaweed itself should probably be updated to reject the request to create a bad bucket name, but the CSI plugin can also help the user out by not using `name` directly ([`name` is documented to be an idempotent identifier, but only a suggested source for a volume name](https://github.com/container-storage-interface/spec/blob/master/spec.md?plain=1#L817)).

Edits to `Dockerfile.dev` should allow for a less environment specific dev build. (It was useful for me working on my Mac.)