### PR TITLE
make volumeBindingMode an option for the StorageClass

### DIFF
--- a/deploy/helm/seaweedfs-csi-driver/templates/storageclass.yaml
+++ b/deploy/helm/seaweedfs-csi-driver/templates/storageclass.yaml
@@ -9,4 +9,5 @@ metadata:
     {{- end }}
 provisioner: {{ .Values.driverName }}
 allowVolumeExpansion: true
+volumeBindingMode: {{ .Values.storageClassVolumeBindingMode | default "Immediate" }}
 {{- end }}


### PR DESCRIPTION
It would be great to add this option to the core functionality.
Because sometimes you don't want to bind a PV to a PVC immediately without an active workload