### PR TITLE
fix: change mountService.enabled default to true

### DIFF
--- a/deploy/helm/seaweedfs-csi-driver/templates/daemonset.yaml
+++ b/deploy/helm/seaweedfs-csi-driver/templates/daemonset.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.node.enabled (not .Values.mountService.enabled) -}}
-{{-   fail "mountService.enabled must be true when node.enabled is true. The CSI driver requires the mount service to function." -}}
+{{-   fail "mountService.enabled must be true when node.enabled is true. The CSI driver node component requires the mount service to mount volumes." -}}
 {{- end -}}
 {{- if .Values.node.enabled}}
 {{- $mountEndpoint := default .Values.mountService.endpoint .Values.node.mountEndpoint }}

--- a/deploy/helm/seaweedfs-csi-driver/values.yaml
+++ b/deploy/helm/seaweedfs-csi-driver/values.yaml
@@ -73,12 +73,12 @@ seaweedfsCsiPlugin:
 
 # Mount Service Configuration
 # The mount service runs as a separate DaemonSet that manages FUSE mounts.
-# This is required for the CSI driver to function properly.
+# This is required for the CSI driver node component to function properly.
 # The node.mountEndpoint, node.mountSocketDir, and node.mountHostPath values
 # default to the corresponding mountService.* values when left empty.
 # NOTE: This deploys an additional DaemonSet with privileged containers.
 mountService:
-  # Must be enabled for the CSI driver to mount volumes
+  # Must be enabled for the CSI driver node component to mount volumes
   enabled: true
   image:  chrislusf/seaweedfs-mount:dev
   # Endpoint for communication between CSI driver and mount service


### PR DESCRIPTION
## Summary

The CSI driver code requires the mount service to function - there is no fallback to the old in-process mounting method. When `mountService.enabled` was set to `false` (the previous default), the driver would fail with:

```
GRPC error: dial unix /var/lib/seaweedfs-mount/seaweedfs-mount.sock: connect: no such file or directory
```

## Changes

- Changed `mountService.enabled` default from `false` to `true` in `values.yaml`
- Updated comments to clarify that the mount service is required for the CSI driver to function

## Testing

Verified with `helm template` that both the mount service DaemonSet and node DaemonSet are created with proper configuration when using default values.

Fixes #216

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Changes**
  * Mount service is now required and enabled by default for the CSI driver.
  * Expanded mount service configuration options: host path, socket directory, security context (privileged, SYS_ADMIN, allowPrivilegeEscalation), update strategy, affinity, tolerations, resources, priority class, and service account.

* **Bug Fixes / Validation**
  * Added early validation to prevent incompatible mountService/node settings with a descriptive error.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->