### PR TITLE
Using multiple ports with the same name is not allowed in k8s pod

### DIFF
--- a/deploy/helm/seaweedfs-csi-driver/templates/daemonset.yaml
+++ b/deploy/helm/seaweedfs-csi-driver/templates/daemonset.yaml
@@ -193,6 +193,7 @@ spec:
             httpGet:
               path: /healthz
               port: 9808
+            {{- with .Values.node.livenessProbe }}
             {{- with .failureThreshold }}
             failureThreshold: {{ . }}
             {{- end }}
@@ -204,6 +205,7 @@ spec:
             {{- end }}
             {{- with .periodSeconds }}
             periodSeconds: {{ . }}
+            {{- end }}
             {{- end }}
         {{- end }}
 

--- a/deploy/helm/seaweedfs-csi-driver/templates/deployment.yaml
+++ b/deploy/helm/seaweedfs-csi-driver/templates/deployment.yaml
@@ -218,6 +218,7 @@ spec:
             httpGet:
               path: /healthz
               port: 9808
+            {{- with .Values.controller.livenessProbe }}
             {{- with .failureThreshold }}
             failureThreshold: {{ . }}
             {{- end }}
@@ -229,6 +230,7 @@ spec:
             {{- end }}
             {{- with .periodSeconds }}
             periodSeconds: {{ . }}
+            {{- end }}
             {{- end }}
         {{- end }}
 


### PR DESCRIPTION
There is a warning message with latest (1.35) kubernetes - it says that healthz port  is shadowing each other and only first one healthz port will be used for all checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized and simplified liveness/health-check configurations across CSI components.
  * Replaced mixed/legacy probe references with explicit per-component health checks for consistent monitoring.

* **Bug Fixes**
  * Removed redundant node-level probe to reduce false failures and improve pod stability.
  * Added/updated probes to improve crash detection and recovery for controller and sidecar components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->