### PR TITLE
feat(helm): add configurable security.toml mount for JWT/gRPC/HTTP security

### DIFF
--- a/deploy/helm/seaweedfs-csi-driver/templates/_helpers.tpl
+++ b/deploy/helm/seaweedfs-csi-driver/templates/_helpers.tpl
@@ -1,3 +1,53 @@
 {{- define "seaweedfs-csi-driver.name" -}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Whether a valid security.toml source is configured.
+*/}}
+{{- define "seaweedfs-csi-driver.security-enabled" -}}
+{{- if .Values.security.enabled -}}
+{{- if not (or .Values.security.existingSecret .Values.security.existingConfigMap (and .Values.security.create .Values.security.content)) -}}
+{{- fail "security.enabled is true but no source configured. Set one of: security.existingSecret, security.existingConfigMap, or security.create with security.content." -}}
+{{- end -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+Security volume definition.
+Produces a volume entry sourcing security.toml from the appropriate Secret or ConfigMap.
+*/}}
+{{- define "seaweedfs-csi-driver.security-volume" -}}
+{{- if include "seaweedfs-csi-driver.security-enabled" . -}}
+- name: security-config
+{{- if .Values.security.existingSecret }}
+  secret:
+    secretName: {{ .Values.security.existingSecret }}
+{{- else if .Values.security.existingConfigMap }}
+  configMap:
+    name: {{ .Values.security.existingConfigMap }}
+{{- else if eq .Values.security.type "secret" }}
+  secret:
+    secretName: {{ template "seaweedfs-csi-driver.name" . }}-security-config
+{{- else if eq .Values.security.type "configmap" }}
+  configMap:
+    name: {{ template "seaweedfs-csi-driver.name" . }}-security-config
+{{- else }}
+{{- fail (printf "security.type must be \"secret\" or \"configmap\", got: %s" .Values.security.type) -}}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Security volumeMount definition.
+Mounts security.toml to /etc/seaweedfs/security.toml.
+*/}}
+{{- define "seaweedfs-csi-driver.security-volumemount" -}}
+{{- if include "seaweedfs-csi-driver.security-enabled" . -}}
+- name: security-config
+  mountPath: /etc/seaweedfs/security.toml
+  subPath: security.toml
+  readOnly: true
+{{- end }}
+{{- end -}}

--- a/deploy/helm/seaweedfs-csi-driver/templates/daemonset-mount.yaml
+++ b/deploy/helm/seaweedfs-csi-driver/templates/daemonset-mount.yaml
@@ -63,6 +63,7 @@ spec:
               mountPath: /var/run/secrets/app/tls
               readOnly: true
             {{- end }}
+            {{- include "seaweedfs-csi-driver.security-volumemount" . | nindent 12 }}
             {{- if and $mountEndpoint $mountSocketDir $mountHostPath }}
             - name: mount-socket-dir
               mountPath: {{ $mountSocketDir }}
@@ -93,4 +94,5 @@ spec:
           secret:
             secretName: {{ .Values.tlsSecret }}
         {{- end }}
+        {{- include "seaweedfs-csi-driver.security-volume" . | nindent 8 }}
 {{- end }}

--- a/deploy/helm/seaweedfs-csi-driver/templates/daemonset.yaml
+++ b/deploy/helm/seaweedfs-csi-driver/templates/daemonset.yaml
@@ -125,6 +125,7 @@ spec:
               mountPath: /var/run/secrets/app/tls
               readOnly: true
             {{- end }}
+            {{- include "seaweedfs-csi-driver.security-volumemount" . | nindent 12 }}
             - name: cache
               mountPath: /var/cache/seaweedfs
             {{- if and $mountEndpoint $mountSocketDir $mountHostPath }}
@@ -242,6 +243,7 @@ spec:
           secret:
             secretName: {{ .Values.tlsSecret }}
         {{- end }}
+        {{- include "seaweedfs-csi-driver.security-volume" . | nindent 8 }}
         {{- if and $mountEndpoint $mountSocketDir $mountHostPath }}
         - name: mount-socket-dir
           hostPath:

--- a/deploy/helm/seaweedfs-csi-driver/templates/deployment.yaml
+++ b/deploy/helm/seaweedfs-csi-driver/templates/deployment.yaml
@@ -80,6 +80,7 @@ spec:
               mountPath: /var/run/secrets/app/tls
               readOnly: true
            {{- end }}
+           {{- include "seaweedfs-csi-driver.security-volumemount" . | nindent 12 }}
           resources: {{ toYaml .Values.controller.resources | nindent 12 }}
 
         # provisioner
@@ -242,3 +243,4 @@ spec:
           secret:
             secretName: {{ .Values.tlsSecret }}
         {{- end }}
+        {{- include "seaweedfs-csi-driver.security-volume" . | nindent 8 }}

--- a/deploy/helm/seaweedfs-csi-driver/templates/secret-security.yaml
+++ b/deploy/helm/seaweedfs-csi-driver/templates/secret-security.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.security.enabled .Values.security.create .Values.security.content (not .Values.security.existingSecret) (not .Values.security.existingConfigMap) }}
+{{- if eq .Values.security.type "secret" }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "seaweedfs-csi-driver.name" . }}-security-config
+  labels:
+    app: {{ template "seaweedfs-csi-driver.name" . }}
+type: Opaque
+stringData:
+  security.toml: |
+    {{- .Values.security.content | nindent 4 }}
+{{- else if eq .Values.security.type "configmap" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "seaweedfs-csi-driver.name" . }}-security-config
+  labels:
+    app: {{ template "seaweedfs-csi-driver.name" . }}
+data:
+  security.toml: |
+    {{- .Values.security.content | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/seaweedfs-csi-driver/values.yaml
+++ b/deploy/helm/seaweedfs-csi-driver/values.yaml
@@ -11,6 +11,31 @@ tlsSecret: ""
 #concurrentWriters: 128
 #concurrentReaders: 128
 
+# Security configuration for SeaweedFS security.toml
+# Mounts security.toml to /etc/seaweedfs/security.toml in seaweedfs-mount
+# and csi-seaweedfs-plugin containers, enabling JWT / gRPC / HTTP security.
+security:
+  enabled: false
+  # Reference an existing Secret containing security.toml (key must be "security.toml")
+  existingSecret: ""
+  # Reference an existing ConfigMap containing security.toml (key must be "security.toml")
+  existingConfigMap: ""
+  # If neither existingSecret nor existingConfigMap is set, the chart can create one for you.
+  # Set create: true and provide the content below.
+  create: false
+  # "secret" or "configmap" — type of resource to create when create=true
+  type: secret
+  # Inline security.toml content used when create=true. Example:
+  #   content: |
+  #     [jwt.signing.read]
+  #     key = "your-jwt-read-key"
+  #     [grpc]
+  #     ca = "/usr/local/share/ca-certificates/ca.crt"
+  #     [grpc.client]
+  #     cert = "/usr/local/share/ca-certificates/tls.crt"
+  #     key  = "/usr/local/share/ca-certificates/tls.key"
+  content: ""
+
 imagePullPolicy: "IfNotPresent"
 
 #imagePullSecrets:


### PR DESCRIPTION
# What problem are we solving

When a SeaweedFS cluster enables JWT security (`jwt.signing.read` / `jwt.filer_signing.read`), `weed mount` needs `/etc/seaweedfs/security.toml` to obtain signing keys. Without it, read requests from the CSI driver return `401 Unauthorized`.

The current Helm chart has no user-controllable entry point to mount a custom `security.toml`.

# How are we solving the problem?

Add a `security` values block (`security.enabled: false` by default) that mounts `security.toml` to `/etc/seaweedfs/security.toml` in `seaweedfs-mount`, `csi-seaweedfs-plugin` (node & controller). Supports referencing an existing Secret/ConfigMap or inline content with auto-created resources.

# How is the PR tested?

Tested helm chart locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added security configuration support to the Helm chart for the SeaweedFS CSI driver.
  * Users can enable security, provide inline security.toml content, or reference existing Secret/ConfigMap resources.
  * Chart can optionally create the Secret/ConfigMap from provided content when requested.
  * Security configuration is mounted into CSI driver containers as a read-only file for runtime use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->