### PR TITLE
fix: refuse to RemoveAll a still-mounted staging path

### DIFF
--- a/pkg/driver/mount_util.go
+++ b/pkg/driver/mount_util.go
@@ -2,6 +2,7 @@ package driver
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"time"
 
@@ -65,34 +66,69 @@ func isStagingPathHealthy(stagingPath string) bool {
 
 // cleanupStaleStagingPath cleans up a stale or corrupted staging mount point.
 // It attempts to unmount and remove the directory.
+//
+// Safety invariant: this function MUST NOT call os.RemoveAll on a path that
+// is still a live mount point. If the staging path is still a working FUSE
+// mount, RemoveAll would walk into the mount and recursively unlink user
+// data through it. Callers (health monitor recovery, NodeStage/NodePublish
+// re-stage) must treat a refusal as a hard failure rather than re-staging
+// over an undeleted mount.
 func cleanupStaleStagingPath(stagingPath string) error {
 	glog.Infof("cleaning up stale staging path %s", stagingPath)
 
-	// Try to unmount first (handles corrupted mounts)
-	if err := mountutil.Unmount(stagingPath); err != nil {
-		glog.V(4).Infof("unmount staging path %s (may already be unmounted): %v", stagingPath, err)
+	// Surface unmount errors. A failed unmount almost always means the
+	// FUSE mount is still alive (EBUSY because pods or bind mounts still
+	// pin it), and silently dropping the error is what lets the
+	// post-unmount RemoveAll below recurse into a live mount.
+	unmountErr := mountutil.Unmount(stagingPath)
+	if unmountErr != nil {
+		glog.Warningf("unmount staging path %s failed: %v", stagingPath, unmountErr)
 	}
 
-	// Check if directory still exists and remove it
-	// Use RemoveAll to handle cases where directory is not empty after imperfect unmount
-	if _, err := os.Stat(stagingPath); err == nil {
-		if err := os.RemoveAll(stagingPath); err != nil {
-			glog.Warningf("failed to remove staging path %s: %v", stagingPath, err)
-			return err
+	_, statErr := os.Stat(stagingPath)
+	if statErr != nil {
+		if os.IsNotExist(statErr) {
+			glog.Infof("successfully cleaned up staging path %s", stagingPath)
+			return nil
 		}
-	} else if !os.IsNotExist(err) {
-		// If stat fails with a different error (like corrupted mount), try force cleanup
-		if mount.IsCorruptedMnt(err) {
-			// Force unmount for corrupted mounts
+		if mount.IsCorruptedMnt(statErr) {
+			// FUSE daemon is dead (ENOTCONN); the kernel will reject
+			// reads/writes through this mount, so CleanupMountPoint
+			// cannot leak deletes through a live FUSE.
 			if cleanupErr := mount.CleanupMountPoint(stagingPath, mountutil, true); cleanupErr != nil {
 				glog.Warningf("failed to cleanup corrupted mount point %s: %v", stagingPath, cleanupErr)
 				return cleanupErr
 			}
-		} else {
-			// stat failed with an unexpected error, return it
-			glog.Warningf("stat on staging path %s failed during cleanup: %v", stagingPath, err)
-			return err
+			glog.Infof("successfully cleaned up corrupted staging path %s", stagingPath)
+			return nil
 		}
+		glog.Warningf("stat on staging path %s failed during cleanup: %v", stagingPath, statErr)
+		return statErr
+	}
+
+	// Re-check whether the path is still a mount point AFTER unmount.
+	// If it is, the unmount failed (or completed only as a lazy detach
+	// while the kernel still routes I/O to the FUSE daemon) and
+	// RemoveAll would walk a live FUSE mount.
+	isMnt, mntErr := mountutil.IsMountPoint(stagingPath)
+	if mntErr != nil {
+		if mount.IsCorruptedMnt(mntErr) {
+			if cleanupErr := mount.CleanupMountPoint(stagingPath, mountutil, true); cleanupErr != nil {
+				glog.Warningf("failed to cleanup corrupted mount point %s: %v", stagingPath, cleanupErr)
+				return cleanupErr
+			}
+			glog.Infof("successfully cleaned up corrupted staging path %s", stagingPath)
+			return nil
+		}
+		return fmt.Errorf("check mount point %s after unmount: %w", stagingPath, mntErr)
+	}
+	if isMnt {
+		return fmt.Errorf("refuse to remove staging path %s: still a mount point after unmount (unmount err: %v); not deleting through a live FUSE", stagingPath, unmountErr)
+	}
+
+	if err := os.RemoveAll(stagingPath); err != nil {
+		glog.Warningf("failed to remove staging path %s: %v", stagingPath, err)
+		return err
 	}
 
 	glog.Infof("successfully cleaned up staging path %s", stagingPath)

--- a/pkg/driver/mount_util.go
+++ b/pkg/driver/mount_util.go
@@ -64,6 +64,19 @@ func isStagingPathHealthy(stagingPath string) bool {
 	return true
 }
 
+// cleanupCorruptedStagingPath force-cleans a staging path whose FUSE
+// daemon is already dead (ENOTCONN / IsCorruptedMnt). Safe because the
+// kernel will reject reads/writes through a corrupted mount, so cleanup
+// cannot propagate deletes through a live FUSE.
+func cleanupCorruptedStagingPath(stagingPath string) error {
+	if err := mount.CleanupMountPoint(stagingPath, mountutil, true); err != nil {
+		glog.Warningf("failed to cleanup corrupted mount point %s: %v", stagingPath, err)
+		return err
+	}
+	glog.Infof("successfully cleaned up corrupted staging path %s", stagingPath)
+	return nil
+}
+
 // cleanupStaleStagingPath cleans up a stale or corrupted staging mount point.
 // It attempts to unmount and remove the directory.
 //
@@ -85,22 +98,17 @@ func cleanupStaleStagingPath(stagingPath string) error {
 		glog.Warningf("unmount staging path %s failed: %v", stagingPath, unmountErr)
 	}
 
-	_, statErr := os.Stat(stagingPath)
+	// Use Lstat so a leftover dangling symlink at stagingPath is still
+	// discoverable (and removable) instead of being mis-classified by
+	// stat-following ENOENT.
+	_, statErr := os.Lstat(stagingPath)
 	if statErr != nil {
 		if os.IsNotExist(statErr) {
 			glog.Infof("successfully cleaned up staging path %s", stagingPath)
 			return nil
 		}
 		if mount.IsCorruptedMnt(statErr) {
-			// FUSE daemon is dead (ENOTCONN); the kernel will reject
-			// reads/writes through this mount, so CleanupMountPoint
-			// cannot leak deletes through a live FUSE.
-			if cleanupErr := mount.CleanupMountPoint(stagingPath, mountutil, true); cleanupErr != nil {
-				glog.Warningf("failed to cleanup corrupted mount point %s: %v", stagingPath, cleanupErr)
-				return cleanupErr
-			}
-			glog.Infof("successfully cleaned up corrupted staging path %s", stagingPath)
-			return nil
+			return cleanupCorruptedStagingPath(stagingPath)
 		}
 		glog.Warningf("stat on staging path %s failed during cleanup: %v", stagingPath, statErr)
 		return statErr
@@ -113,12 +121,7 @@ func cleanupStaleStagingPath(stagingPath string) error {
 	isMnt, mntErr := mountutil.IsMountPoint(stagingPath)
 	if mntErr != nil {
 		if mount.IsCorruptedMnt(mntErr) {
-			if cleanupErr := mount.CleanupMountPoint(stagingPath, mountutil, true); cleanupErr != nil {
-				glog.Warningf("failed to cleanup corrupted mount point %s: %v", stagingPath, cleanupErr)
-				return cleanupErr
-			}
-			glog.Infof("successfully cleaned up corrupted staging path %s", stagingPath)
-			return nil
+			return cleanupCorruptedStagingPath(stagingPath)
 		}
 		return fmt.Errorf("check mount point %s after unmount: %w", stagingPath, mntErr)
 	}


### PR DESCRIPTION
## Summary

`cleanupStaleStagingPath` silently dropped `Unmount` errors and then ran `os.RemoveAll(stagingPath)` whenever the directory still existed. If the FUSE mount was still live — `EBUSY` because pods or bind mounts pinned it, or a lazy detach that left the kernel still routing I/O to the daemon — `RemoveAll` walked into the live mount and recursively unlinked user data through it.

Combined with the v1.4.8+ health monitor (`pkg/driver/health_monitor.go`), this was triggerable in normal operation: a single 5s `ReadDir` timeout in `checkHealth` (`defaultHealthCheckTimeout`) is enough to mark a volume unhealthy, and `recoverVolume` then calls `cleanupStagingFn` → `cleanupStaleStagingPath` → `RemoveAll`. A briefly slow filer or a busy mount on a 30s sweep is enough to wipe live data.

This was reproduced in production on a SeaweedFS 4.00 → 4.22 + CSI 1.3.3 → 1.4.10 upgrade: the filer logged `delete_chunks:true` events for thousands of files, all sourced from the K8s node IPs running the CSI mount processes; the deletions stopped after rolling the server back, which slowed `ReadDir` enough that the false-positive recovery sweep stopped firing.

## Fix

In `cleanupStaleStagingPath`:

- Log unmount errors at `Warning` instead of `V(4)`.
- After `Unmount`, re-check `IsMountPoint`. If the path is still mounted, return an error — refuse `RemoveAll`. The error includes the original unmount error.
- Corrupted (`ENOTCONN`) mounts are still cleaned with `mount.CleanupMountPoint` since the dead FUSE daemon cannot propagate deletes through to backing storage.

All three callers (`recoverVolume` in `health_monitor.go:287`, `NodeStageVolume` in `nodeserver.go:118`, `NodePublishVolume` self-heal in `nodeserver.go:196`) already propagate the error and abort, so the health monitor will simply log and retry on the next tick instead of nuking data.

The bind-path `mount.CleanupMountPoint(p.path, mountutil, true)` calls in `recoverVolume` and `retryPublishPaths` operate on publish-side bind mounts, not on the FUSE root, and so are not in the same blast-radius class — they are not changed here.

## Test plan

- [x] `go build ./...`
- [x] `GOOS=linux go vet ./pkg/driver/...`
- [x] `GOOS=linux go test -count=0 ./pkg/driver/...` (compile-only — tests are linux-only and the dev host is darwin)
- [ ] On a kind cluster, induce a slow `ReadDir` (e.g., large root + brief filer pause) and confirm the health monitor logs the refusal and the volume's data is intact across multiple sweep cycles
- [ ] On a kind cluster, kill the FUSE daemon to produce an `ENOTCONN` mount and confirm the corrupted-mount branch still recovers cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced cleanup operation safety with explicit verification to prevent removal of active mount points
  * Improved error handling during unmount operations with better detection of corrupted or inaccessible mounts
  * Added post-unmount validation to ensure mount points are fully unmounted before removal

<!-- end of auto-generated comment: release notes by coderabbit.ai -->