### PR TITLE
fix: clear stale mountmanager entries when weed mount process dies

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -137,8 +137,12 @@ jobs:
                     emptyDir: {}
           EOF
           
-          # Wait for SeaweedFS pod to be ready (readiness probe checks filer port 8888)
+          # Wait for SeaweedFS pod to be ready (readiness probe checks filer port 8888).
+          # Use rollout status first so the pod actually exists before kubectl wait
+          # queries it — otherwise kubectl wait races kubectl apply and exits with
+          # "no matching resources found".
           echo "Waiting for SeaweedFS to be ready..."
+          kubectl rollout status deployment/seaweedfs -n seaweedfs --timeout=180s
           kubectl wait --for=condition=ready pod -l app=seaweedfs -n seaweedfs --timeout=180s
           kubectl get pods -n seaweedfs
           

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -54,10 +54,22 @@ jobs:
           # Build CSI driver image
           docker build -t seaweedfs-csi-driver:test -f cmd/seaweedfs-csi-driver/Dockerfile .
           kind load docker-image seaweedfs-csi-driver:test --name csi-test
-          
-          # Build mount service image  
+
+          # Build mount service image
           docker build -t seaweedfs-mount:test -f cmd/seaweedfs-mount/Dockerfile .
           kind load docker-image seaweedfs-mount:test --name csi-test
+
+          # Pre-pull and load the SeaweedFS image into kind. Pulling from
+          # Docker Hub at deploy time intermittently hits anonymous-pull
+          # rate limits, leaving the pod in ImagePullBackOff and timing out
+          # the rollout. Retry the docker pull a few times to ride through
+          # transient registry hiccups.
+          for i in 1 2 3; do
+            docker pull chrislusf/seaweedfs:latest && break
+            echo "docker pull attempt $i failed, retrying..."
+            sleep 10
+          done
+          kind load docker-image chrislusf/seaweedfs:latest --name csi-test
 
       - name: Deploy SeaweedFS
         run: |
@@ -106,6 +118,10 @@ jobs:
                 containers:
                   - name: seaweedfs
                     image: chrislusf/seaweedfs:latest
+                    # Use the image preloaded into kind by the workflow so we
+                    # do not re-pull from Docker Hub (anonymous rate limits
+                    # have caused ImagePullBackOff in CI).
+                    imagePullPolicy: IfNotPresent
                     args:
                       - server
                       - -dir=/data

--- a/pkg/driver/health_monitor.go
+++ b/pkg/driver/health_monitor.go
@@ -283,13 +283,25 @@ func (ns *NodeServer) recoverVolume(volumeID string) {
 		}
 	}
 
-	// Step 2: Clean up stale staging path
+	// Step 2: Tear down the FUSE mount via the mount manager so its
+	// internal state is cleared before we re-stage. cleanupStagingFn
+	// only runs a host-level mountutil.Unmount + RemoveAll, which
+	// leaves the manager believing the volume is still mounted; the
+	// follow-up Mount call would then no-op and the recovery would
+	// silently bind onto a dead path. See seaweedfs/seaweedfs-csi-driver#261.
+	if vol.unmounter != nil {
+		if err := vol.unmounter.Unmount(); err != nil {
+			glog.Warningf("health monitor: unmount via mount manager failed for volume %s: %v (continuing with host cleanup)", volumeID, err)
+		}
+	}
+
+	// Step 3: Clean up stale staging path
 	if err := ns.cleanupStagingFn(stagingPath); err != nil {
 		glog.Errorf("health monitor: failed to cleanup stale staging for volume %s: %v", volumeID, err)
 		return
 	}
 
-	// Step 3: Re-stage the volume with a fresh FUSE mount. stageNewVolume
+	// Step 4: Re-stage the volume with a fresh FUSE mount. stageNewVolume
 	// populates volContext/readOnly on the new Volume for us.
 	newVol, err := ns.stageNewVolume(volumeID, stagingPath, vol.volContext, vol.readOnly)
 	if err != nil {
@@ -297,7 +309,7 @@ func (ns *NodeServer) recoverVolume(volumeID string) {
 		return
 	}
 
-	// Step 4: Re-bind all publish paths. Track any failures so they remain
+	// Step 5: Re-bind all publish paths. Track any failures so they remain
 	// registered on the new volume — the next sweep will notice they are
 	// unhealthy via hasUnhealthyPublishPath and drive retryPublishPaths.
 	var failed []publishInfo
@@ -312,14 +324,14 @@ func (ns *NodeServer) recoverVolume(volumeID string) {
 		newVol.AddPublishPath(p.path, p.readOnly)
 	}
 
-	// Step 5: Replace the volume in the map
+	// Step 6: Replace the volume in the map
 	ns.volumes.Store(volumeID, newVol)
 	if len(failed) > 0 {
 		glog.Warningf("health monitor: volume %s recovered with %d publish path failure(s); retryPublishPaths will retry on the next sweep", volumeID, len(failed))
 		return
 	}
 
-	// Step 6: Fix stale mounts inside pod containers. The host-level
+	// Step 7: Fix stale mounts inside pod containers. The host-level
 	// recovery above re-created the bind mount at each publish path,
 	// but containers that were created before the FUSE restart still
 	// hold the old dead mount (rprivate propagation blocks host-side

--- a/pkg/driver/health_monitor.go
+++ b/pkg/driver/health_monitor.go
@@ -317,15 +317,17 @@ func (ns *NodeServer) recoverVolume(volumeID string) {
 		return
 	}
 
-	// Step 5: Re-bind all publish paths. Track any failures so they remain
-	// registered on the new volume — the next sweep will notice they are
-	// unhealthy via hasUnhealthyPublishPath and drive retryPublishPaths.
-	var failed []publishInfo
+	// Step 5: Re-bind all publish paths. Track failures and successes
+	// separately so we can still fix container-side mounts for the
+	// publishes that did recover even if some others failed.
+	var failed, recovered []publishInfo
 	for _, p := range publishes {
 		glog.Infof("health monitor: re-publishing %s for volume %s", p.path, volumeID)
 		if err := newVol.Publish(stagingPath, p.path, p.readOnly); err != nil {
 			glog.Errorf("health monitor: failed to re-publish %s for volume %s: %v", p.path, volumeID, err)
 			failed = append(failed, p)
+		} else {
+			recovered = append(recovered, p)
 		}
 		// Always re-register the path so retryPublishPaths can see it
 		// on the next sweep and so Unpublish can tear it down correctly.
@@ -334,22 +336,29 @@ func (ns *NodeServer) recoverVolume(volumeID string) {
 
 	// Step 6: Replace the volume in the map
 	ns.volumes.Store(volumeID, newVol)
+
+	// Step 7: Fix stale mounts inside pod containers for the publishes
+	// that succeeded. The host-level recovery above re-created the bind
+	// mount at each publish path, but containers that were created
+	// before the FUSE restart still hold the old dead mount (rprivate
+	// propagation blocks host-side changes from reaching them). Enter
+	// each container's mount namespace and replace the stale mount with
+	// a fresh bind from the recovered staging path.
+	//
+	// Run this for the recovered set even when len(failed) > 0:
+	// hasUnhealthyPublishPath only checks the host bind mount, so a
+	// publish whose host side is healthy but whose containers still see
+	// the old mount would never be picked up by retryPublishPaths on
+	// later sweeps.
+	if oldDevice != "" {
+		for _, p := range recovered {
+			remountInContainers(p.path, stagingPath, oldDevice, p.readOnly)
+		}
+	}
+
 	if len(failed) > 0 {
 		glog.Warningf("health monitor: volume %s recovered with %d publish path failure(s); retryPublishPaths will retry on the next sweep", volumeID, len(failed))
 		return
-	}
-
-	// Step 7: Fix stale mounts inside pod containers. The host-level
-	// recovery above re-created the bind mount at each publish path,
-	// but containers that were created before the FUSE restart still
-	// hold the old dead mount (rprivate propagation blocks host-side
-	// changes from reaching them). Enter each container's mount
-	// namespace and replace the stale mount with a fresh bind from the
-	// recovered staging path.
-	if oldDevice != "" {
-		for _, p := range publishes {
-			remountInContainers(p.path, stagingPath, oldDevice, p.readOnly)
-		}
 	}
 
 	glog.Infof("health monitor: volume %s successfully recovered", volumeID)

--- a/pkg/driver/health_monitor.go
+++ b/pkg/driver/health_monitor.go
@@ -291,7 +291,15 @@ func (ns *NodeServer) recoverVolume(volumeID string) {
 	// silently bind onto a dead path. See seaweedfs/seaweedfs-csi-driver#261.
 	if vol.unmounter != nil {
 		if err := vol.unmounter.Unmount(); err != nil {
-			glog.Warningf("health monitor: unmount via mount manager failed for volume %s: %v (continuing with host cleanup)", volumeID, err)
+			// Abort recovery: if the manager refuses to release the
+			// volume, its in-memory entry is likely still stale and
+			// the follow-up Mount would hit the same "already
+			// mounted" no-op we are trying to escape. Worse, running
+			// host-level RemoveAll on a path the manager still
+			// considers mounted risks deleting user data through a
+			// live FUSE (#262). Let the next sweep retry instead.
+			glog.Errorf("health monitor: unmount via mount manager failed for volume %s, aborting recovery: %v", volumeID, err)
+			return
 		}
 	}
 

--- a/pkg/driver/health_monitor_test.go
+++ b/pkg/driver/health_monitor_test.go
@@ -37,6 +37,11 @@ type fakeMountState struct {
 	unmountCalls     int
 	bindMountCalls   int
 	bindMountTargets []string
+
+	// unstageErr, when non-nil, is returned from stateUnmounter.Unmount.
+	// Lets tests exercise the recovery path's response to a manager
+	// teardown failure.
+	unstageErr error
 }
 
 func newFakeMountState() *fakeMountState {
@@ -82,8 +87,9 @@ type stateUnmounter struct{ state *fakeMountState }
 func (u *stateUnmounter) Unmount() error {
 	u.state.mu.Lock()
 	u.state.unstageCalls++
+	err := u.state.unstageErr
 	u.state.mu.Unlock()
-	return nil
+	return err
 }
 
 // newNodeServerWithFakes wires a NodeServer to a fakeMountState, bypassing
@@ -238,6 +244,56 @@ func TestHealthMonitorRecoversStaleMount(t *testing.T) {
 	})
 	if !seen[publishA] || !seen[publishB] {
 		t.Errorf("expected publish paths %q and %q tracked, got %v", publishA, publishB, seen)
+	}
+}
+
+// TestHealthMonitorAbortsOnUnmounterError verifies the recovery path
+// bails out when the volume's unmounter (which talks to the mount
+// manager) returns an error. Continuing into cleanup/re-stage with the
+// manager still holding a stale entry would either fall back into the
+// "already mounted" no-op or, with PR #262 not yet in place, risk a
+// host-level RemoveAll on a still-live FUSE mount.
+func TestHealthMonitorAbortsOnUnmounterError(t *testing.T) {
+	state := newFakeMountState()
+	ns := newNodeServerWithFakes(t, state)
+
+	stagingPath := filepath.Join(t.TempDir(), "staging")
+	volCtx := map[string]string{"collection": "c"}
+
+	vol, err := ns.stageNewVolume("vol-1", stagingPath, volCtx, false)
+	if err != nil {
+		t.Fatalf("stageNewVolume: %v", err)
+	}
+	vol.volContext = volCtx
+	ns.volumes.Store("vol-1", vol)
+
+	state.mu.Lock()
+	state.unstageErr = errors.New("simulated manager unmount failure")
+	state.mu.Unlock()
+	state.healthy.Store(false)
+
+	ns.checkAndRecoverVolumes()
+	ns.recoveryWg.Wait()
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.unstageCalls != 1 {
+		t.Errorf("expected the unmounter to be invoked exactly once, got %d", state.unstageCalls)
+	}
+	// Recovery must abort: no host cleanup, no re-stage, no re-bind.
+	if state.cleanupCalls != 0 {
+		t.Errorf("expected no staging cleanup after manager-unmount failure, got %d", state.cleanupCalls)
+	}
+	if state.stageCalls != 1 {
+		t.Errorf("expected no re-stage after manager-unmount failure, got %d", state.stageCalls)
+	}
+	// Original volume must remain in the map so the next sweep can retry.
+	got, ok := ns.volumes.Load("vol-1")
+	if !ok {
+		t.Fatal("volume removed from map after aborted recovery")
+	}
+	if got.(*Volume) != vol {
+		t.Error("expected original volume preserved after aborted recovery")
 	}
 }
 

--- a/pkg/driver/health_monitor_test.go
+++ b/pkg/driver/health_monitor_test.go
@@ -208,6 +208,14 @@ func TestHealthMonitorRecoversStaleMount(t *testing.T) {
 	if state.bindMountCalls != 4 {
 		t.Errorf("expected 4 total bind mounts (2 initial + 2 recovery), got %d", state.bindMountCalls)
 	}
+	// Recovery must tear down the previous FUSE mount via the volume's
+	// unmounter so the mount manager clears its in-memory state. Without
+	// this, the manager would falsely report "already mounted" on the
+	// follow-up Mount call and the recovery would silently bind onto a
+	// dead path. Regression test for seaweedfs/seaweedfs-csi-driver#261.
+	if state.unstageCalls != 1 {
+		t.Errorf("expected 1 unstage (mount-manager teardown) during recovery, got %d", state.unstageCalls)
+	}
 
 	// --- Verify the replacement volume is tracked correctly ---
 	got, ok := ns.volumes.Load("vol-1")

--- a/pkg/mountmanager/keymutex.go
+++ b/pkg/mountmanager/keymutex.go
@@ -15,7 +15,3 @@ func (km *keyMutex) get(key string) *sync.Mutex {
 	m, _ := km.mutexes.LoadOrStore(key, &sync.Mutex{})
 	return m.(*sync.Mutex)
 }
-
-func (km *keyMutex) delete(key string) {
-	km.mutexes.Delete(key)
-}

--- a/pkg/mountmanager/manager.go
+++ b/pkg/mountmanager/manager.go
@@ -111,7 +111,8 @@ func (m *Manager) watchProcessExit(volumeID string, entry *mountEntry) {
 	defer m.mu.Unlock()
 	if existing, ok := m.mounts[volumeID]; ok && existing == entry {
 		delete(m.mounts, volumeID)
-		m.locks.delete(volumeID)
+		// See removeMount: do not delete the per-volume lock — a
+		// concurrent Mount/Unmount may still be holding it.
 		glog.Infof("removed mount entry for volume %s after weed mount process exited (target: %s)", volumeID, entry.targetPath)
 	}
 }
@@ -166,7 +167,13 @@ func (m *Manager) removeMount(volumeID string) *mountEntry {
 	defer m.mu.Unlock()
 	entry := m.mounts[volumeID]
 	delete(m.mounts, volumeID)
-	m.locks.delete(volumeID)
+	// Intentionally do NOT delete the per-volume lock here. If a caller
+	// is still holding the lock from m.locks.get(volumeID), deleting it
+	// would let a concurrent caller receive a brand-new lock from the
+	// next m.locks.get() and enter the critical section in parallel —
+	// splitting Mount/Unmount serialization for the same volume. The
+	// lock map grows by one entry per ever-mounted volume, which is
+	// negligible for the manager's lifetime.
 	return entry
 }
 

--- a/pkg/mountmanager/manager.go
+++ b/pkg/mountmanager/manager.go
@@ -59,11 +59,25 @@ func (m *Manager) Mount(req *MountRequest) (*MountResponse, error) {
 	defer lock.Unlock()
 
 	if entry := m.getMount(req.VolumeID); entry != nil {
-		if entry.targetPath == req.TargetPath {
-			glog.Infof("volume %s already mounted at %s", req.VolumeID, req.TargetPath)
-			return &MountResponse{LocalSocket: entry.localSocket}, nil
+		// If the previous weed mount process has died, the entry is
+		// stale and the FUSE mount is dead. Tear down the stale entry
+		// so we can start a fresh process; otherwise we would falsely
+		// report "already mounted" and a CSI-driver recovery would
+		// silently bind-mount onto a dead path. See seaweedfs/seaweedfs-csi-driver#261.
+		select {
+		case <-entry.process.exited:
+			glog.Warningf("volume %s previous weed mount process has exited; replacing stale entry with a fresh mount", req.VolumeID)
+			// Wait for wait()'s post-exit cleanup (FUSE unmount) to finish
+			// so ensureTargetClean below sees a quiescent path.
+			<-entry.process.done
+			m.removeMount(req.VolumeID)
+		default:
+			if entry.targetPath == req.TargetPath {
+				glog.Infof("volume %s already mounted at %s", req.VolumeID, req.TargetPath)
+				return &MountResponse{LocalSocket: entry.localSocket}, nil
+			}
+			return nil, fmt.Errorf("volume %s already mounted at %s", req.VolumeID, entry.targetPath)
 		}
-		return nil, fmt.Errorf("volume %s already mounted at %s", req.VolumeID, entry.targetPath)
 	}
 
 	entry, err := m.startMount(req)
@@ -75,8 +89,31 @@ func (m *Manager) Mount(req *MountRequest) (*MountResponse, error) {
 	m.mounts[req.VolumeID] = entry
 	m.mu.Unlock()
 
+	// Proactively clear the entry once the weed mount process exits,
+	// even if Unmount is never called. Without this, a process that
+	// crashes on its own (e.g. backend errors) leaves a stale entry
+	// that fools later Mount calls into reporting success without
+	// starting a new process.
+	go m.watchProcessExit(req.VolumeID, entry)
+
 	glog.Infof("started weed mount process for volume %s at %s", req.VolumeID, req.TargetPath)
 	return &MountResponse{LocalSocket: entry.localSocket}, nil
+}
+
+// watchProcessExit removes the entry for volumeID once its weed mount
+// process has finished exiting. It is safe to run concurrently with
+// Unmount: if Unmount has already removed the entry (or replaced it
+// with a fresh mount), the identity check ensures we leave the new
+// entry alone.
+func (m *Manager) watchProcessExit(volumeID string, entry *mountEntry) {
+	<-entry.process.done
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if existing, ok := m.mounts[volumeID]; ok && existing == entry {
+		delete(m.mounts, volumeID)
+		m.locks.delete(volumeID)
+		glog.Infof("removed mount entry for volume %s after weed mount process exited (target: %s)", volumeID, entry.targetPath)
+	}
 }
 
 // Unmount terminates the weed mount process associated with the provided request.
@@ -226,7 +263,13 @@ type mountEntry struct {
 type weedMountProcess struct {
 	cmd    *exec.Cmd
 	target string
-	done   chan struct{}
+	// exited is closed as soon as cmd.Wait() returns, so callers can
+	// detect that the weed mount process is gone without waiting for
+	// the post-exit FUSE unmount step.
+	exited chan struct{}
+	// done is closed after wait() finishes its full cleanup (including
+	// the kubeMounter.Unmount of the target).
+	done chan struct{}
 }
 
 func startWeedMountProcess(command string, args []string, target string, volumeID string) (*weedMountProcess, error) {
@@ -255,6 +298,7 @@ func startWeedMountProcess(command string, args []string, target string, volumeI
 	process := &weedMountProcess{
 		cmd:    cmd,
 		target: target,
+		exited: make(chan struct{}),
 		done:   make(chan struct{}),
 	}
 
@@ -276,6 +320,10 @@ func (p *weedMountProcess) wait() {
 	} else {
 		glog.Infof("weed mount exit (pid: %d, target: %s)", p.cmd.Process.Pid, p.target)
 	}
+
+	// Signal exit immediately so Manager.Mount can detect a dead
+	// process without waiting for the post-exit unmount step.
+	close(p.exited)
 
 	// Brief delay to allow FUSE cleanup and pending I/O to complete before unmounting
 	time.Sleep(100 * time.Millisecond)

--- a/pkg/mountmanager/manager_test.go
+++ b/pkg/mountmanager/manager_test.go
@@ -1,0 +1,96 @@
+package mountmanager
+
+import (
+	"testing"
+	"time"
+)
+
+// TestWatchProcessExitRemovesStaleEntry verifies that the manager's
+// background watcher clears a mount entry from its map when the weed
+// mount process exits on its own. Without this, a future Mount call for
+// the same volume would falsely receive an "already mounted" no-op
+// because the manager's state never noticed the dead process.
+// Regression test for seaweedfs/seaweedfs-csi-driver#261.
+func TestWatchProcessExitRemovesStaleEntry(t *testing.T) {
+	m := NewManager(Config{})
+
+	process := &weedMountProcess{
+		target: "/tmp/test-target",
+		exited: make(chan struct{}),
+		done:   make(chan struct{}),
+	}
+	entry := &mountEntry{
+		volumeID:    "vol-1",
+		targetPath:  "/tmp/test-target",
+		cacheDir:    "/tmp/test-cache",
+		localSocket: "/tmp/test.sock",
+		process:     process,
+	}
+	m.mounts["vol-1"] = entry
+
+	go m.watchProcessExit("vol-1", entry)
+
+	// Sanity: entry is still tracked while the process is alive.
+	if got := m.getMount("vol-1"); got != entry {
+		t.Fatalf("expected entry tracked before process exit, got %v", got)
+	}
+
+	// Simulate the weed mount process dying.
+	close(process.exited)
+	close(process.done)
+
+	// The watcher should remove the entry; poll briefly to give it time.
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		if m.getMount("vol-1") == nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("watcher did not remove stale entry after weed mount process exited")
+}
+
+// TestWatchProcessExitLeavesReplacedEntry verifies that if a fresh
+// mount has replaced the original entry by the time the watcher fires,
+// the watcher does not delete the new entry. The identity check in
+// watchProcessExit guards against the watcher and a concurrent
+// Unmount/re-Mount racing on the same volumeID slot.
+func TestWatchProcessExitLeavesReplacedEntry(t *testing.T) {
+	m := NewManager(Config{})
+
+	oldProcess := &weedMountProcess{
+		target: "/tmp/test-target",
+		exited: make(chan struct{}),
+		done:   make(chan struct{}),
+	}
+	oldEntry := &mountEntry{
+		volumeID: "vol-1",
+		process:  oldProcess,
+	}
+
+	newProcess := &weedMountProcess{
+		target: "/tmp/test-target",
+		exited: make(chan struct{}),
+		done:   make(chan struct{}),
+	}
+	newEntry := &mountEntry{
+		volumeID: "vol-1",
+		process:  newProcess,
+	}
+
+	// Put the new entry in the map (as if a fresh mount had replaced
+	// the old one) before kicking off the watcher for the old entry.
+	m.mounts["vol-1"] = newEntry
+
+	go m.watchProcessExit("vol-1", oldEntry)
+
+	close(oldProcess.exited)
+	close(oldProcess.done)
+
+	// Give the watcher a moment to run.
+	time.Sleep(50 * time.Millisecond)
+
+	if got := m.getMount("vol-1"); got != newEntry {
+		t.Fatalf("expected new entry preserved, got %v", got)
+	}
+}

--- a/pkg/mountmanager/manager_test.go
+++ b/pkg/mountmanager/manager_test.go
@@ -82,13 +82,20 @@ func TestWatchProcessExitLeavesReplacedEntry(t *testing.T) {
 	// the old one) before kicking off the watcher for the old entry.
 	m.mounts["vol-1"] = newEntry
 
-	go m.watchProcessExit("vol-1", oldEntry)
+	watcherDone := make(chan struct{})
+	go func() {
+		m.watchProcessExit("vol-1", oldEntry)
+		close(watcherDone)
+	}()
 
 	close(oldProcess.exited)
 	close(oldProcess.done)
 
-	// Give the watcher a moment to run.
-	time.Sleep(50 * time.Millisecond)
+	select {
+	case <-watcherDone:
+	case <-time.After(1 * time.Second):
+		t.Fatal("watcher did not finish")
+	}
 
 	if got := m.getMount("vol-1"); got != newEntry {
 		t.Fatalf("expected new entry preserved, got %v", got)


### PR DESCRIPTION
Fixes #261.

## Summary

When the weed mount process dies on its own (e.g. backend connectivity errors during a node restart), `mountmanager.Manager` never updated its in-memory `mounts` map. The CSI driver's recovery flow would then call `cleanupStaleStagingPath` (host-level `mountutil.Unmount` + `RemoveAll`) and `mounter.Mount`, but `Manager.Mount` returned a no-op "already mounted" response because the stale entry was still present. The recovery **falsely reported success** while the pod's bind mount pointed at a dead/empty staging path — exactly the symptom in #261:

```
I0505 16:21:52.960332 manager.go:63 volume datastore-files-ingress-nginx already mounted at .../globalmount
...
W0505 16:22:22.962998 manager.go:289 sending SIGTERM to weed mount failed: os: process already finished
```

The "already mounted" no-op fired against a process that had already exited, so for ~60 seconds the pod was running with a non-functional mount.

This is independent of #262: that PR prevents `cleanupStaleStagingPath` from `RemoveAll`-ing user data through a still-live mount. This PR addresses the orthogonal "silent recovery failure" path.

## Fix

**`pkg/mountmanager/manager.go`** — make the manager honest about process state:

- Added an `exited` channel on `weedMountProcess` that closes the moment `cmd.Wait()` returns, distinct from `done` which also waits for the post-exit FUSE unmount step.
- `Manager.Mount` now lazy-checks `entry.process.exited`. If the previous process has died, it waits for cleanup, drops the stale entry, and starts a fresh mount instead of the no-op response.
- Added `watchProcessExit` — a per-mount goroutine that proactively removes the entry when the weed mount process exits, even if `Unmount` is never called. An identity check (`existing == entry`) guards against deleting a fresh replacement entry created by a concurrent re-mount.

**`pkg/driver/health_monitor.go`** — make recovery tear down via the manager:

- `recoverVolume` now calls `vol.unmounter.Unmount()` before `cleanupStagingFn`, so the manager's internal state is cleared (and the weed process is terminated) before re-staging. This is the defensive complement to the manager-side fix and ensures correct behavior even when the process is alive but the FUSE is unhealthy.

## Test plan

- [x] `go build ./...`
- [x] `GOOS=linux go build ./...`
- [x] `go vet ./...` and `GOOS=linux go vet ./...`
- [x] `go test -race ./pkg/mountmanager/...` — new tests `TestWatchProcessExitRemovesStaleEntry` and `TestWatchProcessExitLeavesReplacedEntry` pass.
- [x] Extended `TestHealthMonitorRecoversStaleMount` in `pkg/driver/health_monitor_test.go` to assert that recovery now invokes the volume's unmounter exactly once (regression guard for #261).
- [ ] On a kind cluster: kill the weed mount process for a published volume, confirm the manager's entry is cleared, the next health-monitor sweep starts a fresh process, and the pod's bind mount is functional again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery for stale volume mounts with safer teardown, re-staging, and per-path re-binding; recovery now aborts cleanly if unmount fails.
  * Prevented lingering stale mount entries by automatically cleaning up when mount processes terminate.
  * Reduced race conditions in concurrent mount/unmount scenarios.

* **Tests**
  * Added tests verifying recovery behavior, unmount-failure handling, and process-exit cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->