### PR TITLE
fix: harden health-monitor recovery against weed-mount crash scenarios

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -292,27 +292,62 @@ jobs:
           # pod, but not the mount service itself. This is what kvaster
           # observed in production: a transient filer outage causes weed
           # mount to give up and exit, while the mount service stays up.
+          # Fail loudly if there is nothing to kill — otherwise the test
+          # would silently degrade into a no-op that always passes.
           MOUNT_POD=$(kubectl get pod -l app=seaweedfs-mount -o jsonpath='{.items[0].metadata.name}')
           echo "Killing weed mount processes inside $MOUNT_POD..."
-          kubectl exec "$MOUNT_POD" -- sh -c 'pids=$(pgrep -f "weed .*mount" || true); if [ -n "$pids" ]; then echo "killing pids: $pids"; kill -9 $pids; else echo "no weed mount pids found"; fi'
+          KILL_OUTPUT=$(kubectl exec "$MOUNT_POD" -- sh -c 'pids=$(pgrep -f "weed .*mount" || true); if [ -n "$pids" ]; then echo "killing pids: $pids"; kill -9 $pids && echo "killed"; else echo "no weed mount pids found"; fi' 2>&1)
+          echo "$KILL_OUTPUT"
+          if ! echo "$KILL_OUTPUT" | grep -q "^killed$"; then
+            echo "FAIL: no weed mount processes were running, cannot exercise recovery"
+            echo "--- mount service ps ---"
+            kubectl exec "$MOUNT_POD" -- ps -ef || true
+            exit 1
+          fi
 
           # The mount service's wait() handler runs kubeMounter.Unmount
           # 100ms after the process exits, so the staging path will be
           # unmounted host-side within ~1s. Then the next CSI health
           # monitor sweep (default 30s interval) must recover the volume.
+          #
+          # We do NOT treat "first read succeeded" as a pass on its own:
+          # that would also pass on a build where the kill no-op'd or
+          # the kernel cached a stale read for a few seconds before any
+          # recovery happened. Require evidence of recovery — either
+          # the read failed at least once with ENOTCONN/EIO, OR the CSI
+          # node logged a recovery action — before counting a later
+          # successful read as a pass.
           echo "Waiting for health monitor to detect and recover..."
           ATTEMPTS=30
           PASSED=0
+          EVER_BROKEN=0
+          RECOVERY_LOGGED=0
           for i in $(seq 1 $ATTEMPTS); do
-            # Probe the pod's view of the volume. If the stale FUSE
-            # mount is still in place we get ENOTCONN ("transport
-            # endpoint is not connected"); a successful read means the
-            # container-side mount has been replaced.
-            if kubectl exec test-pod -- cat /data/crash_sentinel.txt 2>/dev/null | grep -q "before-crash"; then
-              echo "PASS: pod can read sentinel after ~$((i * 5))s — recovery succeeded with no stale FUSE in the container"
-              PASSED=1
-              break
+            # Look for recovery activity in the CSI node logs.
+            if [ "$RECOVERY_LOGGED" -eq 0 ]; then
+              if kubectl logs "$CSI_NODE_POD" -c csi-seaweedfs-plugin 2>/dev/null | tail -n +"$((LOG_BASELINE + 1))" | grep -qE "health monitor: detected unhealthy|health monitor: recovering volume"; then
+                RECOVERY_LOGGED=1
+                echo "Recovery activity observed in CSI node logs at ~$((i * 5))s"
+              fi
             fi
+
+            READ_OUT=$(kubectl exec test-pod -- cat /data/crash_sentinel.txt 2>&1 || true)
+            case "$READ_OUT" in
+              *"Transport endpoint is not connected"*|*"Input/output error"*)
+                if [ "$EVER_BROKEN" -eq 0 ]; then
+                  echo "Confirmed pod sees stale FUSE at ~$((i * 5))s: $(echo "$READ_OUT" | head -1)"
+                  EVER_BROKEN=1
+                fi
+                ;;
+              *"before-crash"*)
+                if [ "$EVER_BROKEN" -eq 1 ] || [ "$RECOVERY_LOGGED" -eq 1 ]; then
+                  echo "PASS: pod read works again after ~$((i * 5))s (broken_observed=$EVER_BROKEN, recovery_logged=$RECOVERY_LOGGED)"
+                  PASSED=1
+                  break
+                fi
+                ;;
+            esac
+
             # Periodic diagnostics every 15s.
             if [ $((i % 3)) = 0 ]; then
               echo "--- poll $i: pod view of /data ---"
@@ -326,7 +361,11 @@ jobs:
           done
 
           if [ "$PASSED" -ne 1 ]; then
-            echo "FAIL: pod could not read sentinel within $((ATTEMPTS * 5))s after weed mount crash"
+            if [ "$EVER_BROKEN" -eq 0 ] && [ "$RECOVERY_LOGGED" -eq 0 ]; then
+              echo "FAIL: weed mount was killed but neither breakage nor recovery activity was observed within $((ATTEMPTS * 5))s — recovery may not have triggered"
+            else
+              echo "FAIL: recovery did not converge within $((ATTEMPTS * 5))s (broken_observed=$EVER_BROKEN, recovery_logged=$RECOVERY_LOGGED)"
+            fi
             echo "--- CSI node full logs (new lines since crash) ---"
             kubectl logs "$CSI_NODE_POD" -c csi-seaweedfs-plugin 2>/dev/null | tail -n +"$((LOG_BASELINE + 1))"
             echo "--- Mount service logs ---"

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -296,7 +296,13 @@ jobs:
           # would silently degrade into a no-op that always passes.
           MOUNT_POD=$(kubectl get pod -l app=seaweedfs-mount -o jsonpath='{.items[0].metadata.name}')
           echo "Killing weed mount processes inside $MOUNT_POD..."
-          KILL_OUTPUT=$(kubectl exec "$MOUNT_POD" -- sh -c 'pids=$(pgrep -f "weed .*mount" || true); if [ -n "$pids" ]; then echo "killing pids: $pids"; kill -9 $pids && echo "killed"; else echo "no weed mount pids found"; fi' 2>&1)
+          # Match by exact process name "weed" (the weed mount children), not
+          # via pgrep -f, which would match our own shell — its argv contains
+          # the search pattern, so kill -9 $pids would also kill the shell
+          # running this command and terminate kubectl exec with code 137.
+          # The mount service itself runs as "seaweedfs-mount" so it is not a
+          # target; "weed" only appears for the FUSE child processes.
+          KILL_OUTPUT=$(kubectl exec "$MOUNT_POD" -- sh -c 'pids=$(pgrep -x weed || true); if [ -n "$pids" ]; then echo "killing pids: $pids"; kill -9 $pids && echo "killed"; else echo "no weed mount pids found"; fi' 2>&1)
           echo "$KILL_OUTPUT"
           if ! echo "$KILL_OUTPUT" | grep -q "^killed$"; then
             echo "FAIL: no weed mount processes were running, cannot exercise recovery"

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -168,11 +168,16 @@ jobs:
 
       - name: Deploy CSI Driver
         run: |
-          # Deploy CSI driver with test images and correct filer address
-          # The seaweedfs-csi.yaml deploys to 'default' namespace
+          # Deploy CSI driver with test images and correct filer address.
+          # The seaweedfs-csi.yaml is rendered from the helm chart and pins
+          # the released image tag (e.g. chrislusf/seaweedfs-csi-driver:v1.4.5),
+          # so we rewrite *any* chrislusf/seaweedfs-csi-driver:* and
+          # chrislusf/seaweedfs-mount:* reference to the test images we
+          # kind-loaded in the previous step. This guarantees CI is exercising
+          # the code in this PR, not whatever the helm chart happens to pin.
           cat deploy/kubernetes/seaweedfs-csi.yaml | \
-            sed 's|chrislusf/seaweedfs-csi-driver:latest|seaweedfs-csi-driver:test|g' | \
-            sed 's|chrislusf/seaweedfs-mount:latest|seaweedfs-mount:test|g' | \
+            sed -E 's|chrislusf/seaweedfs-csi-driver:[^[:space:]]+|seaweedfs-csi-driver:test|g' | \
+            sed -E 's|chrislusf/seaweedfs-mount:[^[:space:]]+|seaweedfs-mount:test|g' | \
             sed 's|SEAWEEDFS_FILER:8888|seaweedfs.seaweedfs.svc.cluster.local:8888|g' | \
             kubectl apply -f -
           

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -342,6 +342,84 @@ jobs:
             echo "PASS: Mount service restart recovery test passed"
           fi
 
+      - name: Test weed mount crash recovery (issue #261)
+        run: |
+          # Reproduce the scenario from
+          # https://github.com/seaweedfs/seaweedfs-csi-driver/issues/261:
+          # weed mount processes exit on their own (e.g. after a filer
+          # outage they cannot ride out). Their wait() handler runs
+          # kubeMounter.Unmount on the staging path, so by the time the
+          # CSI driver's health monitor sweep notices, getMountDevice
+          # returns empty for the stale staging path. The recovery
+          # must (a) re-stage cleanly and (b) replace the stale FUSE
+          # mount inside the pod's container — otherwise the pod is
+          # left with "transport endpoint is not connected".
+
+          # Pre-crash sentinel.
+          kubectl exec test-pod -- sh -c 'echo "before-crash" > /data/crash_sentinel.txt'
+          kubectl exec test-pod -- cat /data/crash_sentinel.txt | grep "before-crash"
+          echo "Pre-crash sentinel written."
+
+          # Snapshot CSI node log length so we capture only new lines later.
+          CSI_NODE_POD=$(kubectl get pod -l app=seaweedfs-node -o jsonpath='{.items[0].metadata.name}')
+          LOG_BASELINE=$(kubectl logs "$CSI_NODE_POD" -c csi-seaweedfs-plugin 2>/dev/null | wc -l)
+          echo "CSI node log baseline: $LOG_BASELINE lines"
+
+          # Kill the weed mount child process(es) inside the mount service
+          # pod, but not the mount service itself. This is what kvaster
+          # observed in production: a transient filer outage causes weed
+          # mount to give up and exit, while the mount service stays up.
+          MOUNT_POD=$(kubectl get pod -l app=seaweedfs-mount -o jsonpath='{.items[0].metadata.name}')
+          echo "Killing weed mount processes inside $MOUNT_POD..."
+          kubectl exec "$MOUNT_POD" -- sh -c 'pids=$(pgrep -f "weed .*mount" || true); if [ -n "$pids" ]; then echo "killing pids: $pids"; kill -9 $pids; else echo "no weed mount pids found"; fi'
+
+          # The mount service's wait() handler runs kubeMounter.Unmount
+          # 100ms after the process exits, so the staging path will be
+          # unmounted host-side within ~1s. Then the next CSI health
+          # monitor sweep (default 30s interval) must recover the volume.
+          echo "Waiting for health monitor to detect and recover..."
+          ATTEMPTS=30
+          PASSED=0
+          for i in $(seq 1 $ATTEMPTS); do
+            # Probe the pod's view of the volume. If the stale FUSE
+            # mount is still in place we get ENOTCONN ("transport
+            # endpoint is not connected"); a successful read means the
+            # container-side mount has been replaced.
+            if kubectl exec test-pod -- cat /data/crash_sentinel.txt 2>/dev/null | grep -q "before-crash"; then
+              echo "PASS: pod can read sentinel after ~$((i * 5))s — recovery succeeded with no stale FUSE in the container"
+              PASSED=1
+              break
+            fi
+            # Periodic diagnostics every 15s.
+            if [ $((i % 3)) = 0 ]; then
+              echo "--- poll $i: pod view of /data ---"
+              kubectl exec test-pod -- ls /data/ 2>&1 | head -5 || true
+              echo "--- poll $i: CSI node new log lines ---"
+              kubectl logs "$CSI_NODE_POD" -c csi-seaweedfs-plugin 2>/dev/null | tail -n +"$((LOG_BASELINE + 1))" | tail -30
+              echo "--- poll $i: fuse mounts in CSI node namespace ---"
+              kubectl exec "$CSI_NODE_POD" -c csi-seaweedfs-plugin -- cat /proc/self/mountinfo 2>/dev/null | grep fuse || echo "(no fuse mounts)"
+            fi
+            sleep 5
+          done
+
+          if [ "$PASSED" -ne 1 ]; then
+            echo "FAIL: pod could not read sentinel within $((ATTEMPTS * 5))s after weed mount crash"
+            echo "--- CSI node full logs (new lines since crash) ---"
+            kubectl logs "$CSI_NODE_POD" -c csi-seaweedfs-plugin 2>/dev/null | tail -n +"$((LOG_BASELINE + 1))"
+            echo "--- Mount service logs ---"
+            kubectl logs -l app=seaweedfs-mount --tail=200
+            echo "--- Pod describe ---"
+            kubectl describe pod test-pod
+            exit 1
+          fi
+
+          # Verify writes still work after recovery — confirms the
+          # container-side mount really points at a live FUSE, not at
+          # an empty bare directory left behind by an aborted recovery.
+          kubectl exec test-pod -- sh -c 'echo "after-crash" > /data/post_crash.txt'
+          kubectl exec test-pod -- cat /data/post_crash.txt | grep "after-crash"
+          echo "PASS: weed mount crash recovery test passed"
+
       - name: Cleanup
         if: always()
         run: |

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -260,6 +260,89 @@ jobs:
           
           echo "PASS: Functional test passed"
 
+      - name: Test weed mount crash recovery (issue #261)
+        run: |
+          # Reproduce the scenario from
+          # https://github.com/seaweedfs/seaweedfs-csi-driver/issues/261:
+          # weed mount processes exit on their own (e.g. after a filer
+          # outage they cannot ride out). Their wait() handler runs
+          # kubeMounter.Unmount on the staging path, so by the time the
+          # CSI driver's health monitor sweep notices, getMountDevice
+          # returns empty for the stale staging path. The recovery
+          # must (a) re-stage cleanly and (b) replace the stale FUSE
+          # mount inside the pod's container — otherwise the pod is
+          # left with "transport endpoint is not connected".
+          #
+          # This step runs before "Test mount service restart recovery"
+          # so it gets a clean test pod state. The mount-service
+          # restart test is informational/continue-on-error and may
+          # leave the cluster with stale FUSE in containers.
+
+          # Pre-crash sentinel.
+          kubectl exec test-pod -- sh -c 'echo "before-crash" > /data/crash_sentinel.txt'
+          kubectl exec test-pod -- cat /data/crash_sentinel.txt | grep "before-crash"
+          echo "Pre-crash sentinel written."
+
+          # Snapshot CSI node log length so we capture only new lines later.
+          CSI_NODE_POD=$(kubectl get pod -l app=seaweedfs-node -o jsonpath='{.items[0].metadata.name}')
+          LOG_BASELINE=$(kubectl logs "$CSI_NODE_POD" -c csi-seaweedfs-plugin 2>/dev/null | wc -l)
+          echo "CSI node log baseline: $LOG_BASELINE lines"
+
+          # Kill the weed mount child process(es) inside the mount service
+          # pod, but not the mount service itself. This is what kvaster
+          # observed in production: a transient filer outage causes weed
+          # mount to give up and exit, while the mount service stays up.
+          MOUNT_POD=$(kubectl get pod -l app=seaweedfs-mount -o jsonpath='{.items[0].metadata.name}')
+          echo "Killing weed mount processes inside $MOUNT_POD..."
+          kubectl exec "$MOUNT_POD" -- sh -c 'pids=$(pgrep -f "weed .*mount" || true); if [ -n "$pids" ]; then echo "killing pids: $pids"; kill -9 $pids; else echo "no weed mount pids found"; fi'
+
+          # The mount service's wait() handler runs kubeMounter.Unmount
+          # 100ms after the process exits, so the staging path will be
+          # unmounted host-side within ~1s. Then the next CSI health
+          # monitor sweep (default 30s interval) must recover the volume.
+          echo "Waiting for health monitor to detect and recover..."
+          ATTEMPTS=30
+          PASSED=0
+          for i in $(seq 1 $ATTEMPTS); do
+            # Probe the pod's view of the volume. If the stale FUSE
+            # mount is still in place we get ENOTCONN ("transport
+            # endpoint is not connected"); a successful read means the
+            # container-side mount has been replaced.
+            if kubectl exec test-pod -- cat /data/crash_sentinel.txt 2>/dev/null | grep -q "before-crash"; then
+              echo "PASS: pod can read sentinel after ~$((i * 5))s — recovery succeeded with no stale FUSE in the container"
+              PASSED=1
+              break
+            fi
+            # Periodic diagnostics every 15s.
+            if [ $((i % 3)) = 0 ]; then
+              echo "--- poll $i: pod view of /data ---"
+              kubectl exec test-pod -- ls /data/ 2>&1 | head -5 || true
+              echo "--- poll $i: CSI node new log lines ---"
+              kubectl logs "$CSI_NODE_POD" -c csi-seaweedfs-plugin 2>/dev/null | tail -n +"$((LOG_BASELINE + 1))" | tail -30
+              echo "--- poll $i: fuse mounts in CSI node namespace ---"
+              kubectl exec "$CSI_NODE_POD" -c csi-seaweedfs-plugin -- cat /proc/self/mountinfo 2>/dev/null | grep fuse || echo "(no fuse mounts)"
+            fi
+            sleep 5
+          done
+
+          if [ "$PASSED" -ne 1 ]; then
+            echo "FAIL: pod could not read sentinel within $((ATTEMPTS * 5))s after weed mount crash"
+            echo "--- CSI node full logs (new lines since crash) ---"
+            kubectl logs "$CSI_NODE_POD" -c csi-seaweedfs-plugin 2>/dev/null | tail -n +"$((LOG_BASELINE + 1))"
+            echo "--- Mount service logs ---"
+            kubectl logs -l app=seaweedfs-mount --tail=200
+            echo "--- Pod describe ---"
+            kubectl describe pod test-pod
+            exit 1
+          fi
+
+          # Verify writes still work after recovery — confirms the
+          # container-side mount really points at a live FUSE, not at
+          # an empty bare directory left behind by an aborted recovery.
+          kubectl exec test-pod -- sh -c 'echo "after-crash" > /data/post_crash.txt'
+          kubectl exec test-pod -- cat /data/post_crash.txt | grep "after-crash"
+          echo "PASS: weed mount crash recovery test passed"
+
       - name: Test mount service restart recovery
         continue-on-error: true
         run: |
@@ -341,84 +424,6 @@ jobs:
             kubectl exec test-pod -- cat /data/post_restart.txt | grep "after-restart"
             echo "PASS: Mount service restart recovery test passed"
           fi
-
-      - name: Test weed mount crash recovery (issue #261)
-        run: |
-          # Reproduce the scenario from
-          # https://github.com/seaweedfs/seaweedfs-csi-driver/issues/261:
-          # weed mount processes exit on their own (e.g. after a filer
-          # outage they cannot ride out). Their wait() handler runs
-          # kubeMounter.Unmount on the staging path, so by the time the
-          # CSI driver's health monitor sweep notices, getMountDevice
-          # returns empty for the stale staging path. The recovery
-          # must (a) re-stage cleanly and (b) replace the stale FUSE
-          # mount inside the pod's container — otherwise the pod is
-          # left with "transport endpoint is not connected".
-
-          # Pre-crash sentinel.
-          kubectl exec test-pod -- sh -c 'echo "before-crash" > /data/crash_sentinel.txt'
-          kubectl exec test-pod -- cat /data/crash_sentinel.txt | grep "before-crash"
-          echo "Pre-crash sentinel written."
-
-          # Snapshot CSI node log length so we capture only new lines later.
-          CSI_NODE_POD=$(kubectl get pod -l app=seaweedfs-node -o jsonpath='{.items[0].metadata.name}')
-          LOG_BASELINE=$(kubectl logs "$CSI_NODE_POD" -c csi-seaweedfs-plugin 2>/dev/null | wc -l)
-          echo "CSI node log baseline: $LOG_BASELINE lines"
-
-          # Kill the weed mount child process(es) inside the mount service
-          # pod, but not the mount service itself. This is what kvaster
-          # observed in production: a transient filer outage causes weed
-          # mount to give up and exit, while the mount service stays up.
-          MOUNT_POD=$(kubectl get pod -l app=seaweedfs-mount -o jsonpath='{.items[0].metadata.name}')
-          echo "Killing weed mount processes inside $MOUNT_POD..."
-          kubectl exec "$MOUNT_POD" -- sh -c 'pids=$(pgrep -f "weed .*mount" || true); if [ -n "$pids" ]; then echo "killing pids: $pids"; kill -9 $pids; else echo "no weed mount pids found"; fi'
-
-          # The mount service's wait() handler runs kubeMounter.Unmount
-          # 100ms after the process exits, so the staging path will be
-          # unmounted host-side within ~1s. Then the next CSI health
-          # monitor sweep (default 30s interval) must recover the volume.
-          echo "Waiting for health monitor to detect and recover..."
-          ATTEMPTS=30
-          PASSED=0
-          for i in $(seq 1 $ATTEMPTS); do
-            # Probe the pod's view of the volume. If the stale FUSE
-            # mount is still in place we get ENOTCONN ("transport
-            # endpoint is not connected"); a successful read means the
-            # container-side mount has been replaced.
-            if kubectl exec test-pod -- cat /data/crash_sentinel.txt 2>/dev/null | grep -q "before-crash"; then
-              echo "PASS: pod can read sentinel after ~$((i * 5))s — recovery succeeded with no stale FUSE in the container"
-              PASSED=1
-              break
-            fi
-            # Periodic diagnostics every 15s.
-            if [ $((i % 3)) = 0 ]; then
-              echo "--- poll $i: pod view of /data ---"
-              kubectl exec test-pod -- ls /data/ 2>&1 | head -5 || true
-              echo "--- poll $i: CSI node new log lines ---"
-              kubectl logs "$CSI_NODE_POD" -c csi-seaweedfs-plugin 2>/dev/null | tail -n +"$((LOG_BASELINE + 1))" | tail -30
-              echo "--- poll $i: fuse mounts in CSI node namespace ---"
-              kubectl exec "$CSI_NODE_POD" -c csi-seaweedfs-plugin -- cat /proc/self/mountinfo 2>/dev/null | grep fuse || echo "(no fuse mounts)"
-            fi
-            sleep 5
-          done
-
-          if [ "$PASSED" -ne 1 ]; then
-            echo "FAIL: pod could not read sentinel within $((ATTEMPTS * 5))s after weed mount crash"
-            echo "--- CSI node full logs (new lines since crash) ---"
-            kubectl logs "$CSI_NODE_POD" -c csi-seaweedfs-plugin 2>/dev/null | tail -n +"$((LOG_BASELINE + 1))"
-            echo "--- Mount service logs ---"
-            kubectl logs -l app=seaweedfs-mount --tail=200
-            echo "--- Pod describe ---"
-            kubectl describe pod test-pod
-            exit 1
-          fi
-
-          # Verify writes still work after recovery — confirms the
-          # container-side mount really points at a live FUSE, not at
-          # an empty bare directory left behind by an aborted recovery.
-          kubectl exec test-pod -- sh -c 'echo "after-crash" > /data/post_crash.txt'
-          kubectl exec test-pod -- cat /data/post_crash.txt | grep "after-crash"
-          echo "PASS: weed mount crash recovery test passed"
 
       - name: Cleanup
         if: always()

--- a/pkg/driver/container_remount_linux.go
+++ b/pkg/driver/container_remount_linux.go
@@ -335,6 +335,20 @@ func remountViaSetns(containerPID int, containerMountPath, stagingPath string, r
 		return fmt.Errorf("unshare CLONE_FS: %w", err)
 	}
 
+	// Open the staging path in OUR mount namespace BEFORE setns. The
+	// staging path lives at /var/lib/kubelet/plugins/... which exists
+	// in the CSI driver pod (hostPath mount) but NOT inside the user
+	// container's filesystem (e.g. busybox), so referring to it by
+	// path after setns fails with ENOENT. /proc/self/fd/N stays valid
+	// across the namespace switch — /proc is mounted in the container
+	// too — and resolves to the same inode we opened here.
+	sourceFd, err := unix.Open(stagingPath, unix.O_PATH|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return fmt.Errorf("open source %s: %w", stagingPath, err)
+	}
+	defer unix.Close(sourceFd)
+	sourcePath := fmt.Sprintf("/proc/self/fd/%d", sourceFd)
+
 	// Save our current mount namespace so we can restore it.
 	origNS, err := os.Open("/proc/self/ns/mnt")
 	if err != nil {
@@ -373,13 +387,13 @@ func remountViaSetns(containerPID int, containerMountPath, stagingPath string, r
 		glog.V(4).Infof("container remount: umount %s in PID %d: %v (may already be unmounted)", containerMountPath, containerPID, umountErr)
 	}
 
-	// Bind-mount the staging path into the container. The staging path
-	// resides on the host filesystem under /var/lib/kubelet/plugins/
-	// which is accessible from inside the container's mount namespace
-	// because both the CSI driver and pod containers share the same
-	// host filesystem root for kubelet paths.
-	if err := unix.Mount(stagingPath, containerMountPath, "", unix.MS_BIND, ""); err != nil {
-		return fmt.Errorf("bind mount %s -> %s in container PID %d: %w", stagingPath, containerMountPath, containerPID, err)
+	// Bind-mount the staging path into the container by referring to
+	// the pre-setns FD via /proc/self/fd/N. The kernel resolves the
+	// magic link to the inode we opened in the CSI driver's mount
+	// namespace, so the bind succeeds even though the container's
+	// filesystem has no /var/lib/kubelet directory of its own.
+	if err := unix.Mount(sourcePath, containerMountPath, "", unix.MS_BIND, ""); err != nil {
+		return fmt.Errorf("bind mount %s (-> %s) -> %s in container PID %d: %w", sourcePath, stagingPath, containerMountPath, containerPID, err)
 	}
 
 	// A bind mount created with MS_BIND ignores MS_RDONLY in the same

--- a/pkg/driver/container_remount_linux.go
+++ b/pkg/driver/container_remount_linux.go
@@ -335,19 +335,31 @@ func remountViaSetns(containerPID int, containerMountPath, stagingPath string, r
 		return fmt.Errorf("unshare CLONE_FS: %w", err)
 	}
 
-	// Open the staging path in OUR mount namespace BEFORE setns. The
-	// staging path lives at /var/lib/kubelet/plugins/... which exists
-	// in the CSI driver pod (hostPath mount) but NOT inside the user
-	// container's filesystem (e.g. busybox), so referring to it by
-	// path after setns fails with ENOENT. /proc/self/fd/N stays valid
-	// across the namespace switch — /proc is mounted in the container
-	// too — and resolves to the same inode we opened here.
-	sourceFd, err := unix.Open(stagingPath, unix.O_PATH|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	// Build a detached clone of the source mount tree BEFORE setns so
+	// we can carry it into the container's namespace as an fd. Why not
+	// a plain unix.Mount(stagingPath, ...) after setns?
+	//
+	//   1. The staging path /var/lib/kubelet/plugins/... lives only in
+	//      the CSI driver pod's mount namespace (hostPath mount). The
+	//      user container's image (e.g. busybox) has no such directory,
+	//      so the kernel's path lookup fails with ENOENT after setns.
+	//   2. /proc/self/fd/N is also a non-starter: the kernel reads the
+	//      magic symlink and re-walks the original path string in the
+	//      *current* mount namespace, hitting the same ENOENT (or, in
+	//      the unit-test setup, EINVAL).
+	//
+	// open_tree(OPEN_TREE_CLONE) gives us an fd that holds a detached
+	// copy of the source's mount tree, anchored to its dentry. We can
+	// then move_mount() it into the container's namespace by fd, and
+	// the kernel never has to walk a path that the container can't see.
+	// Available since Linux 5.2; kind images and ubuntu-latest GHA
+	// runners both ship newer kernels.
+	sourceFd, err := unix.OpenTree(unix.AT_FDCWD, stagingPath,
+		uint(unix.OPEN_TREE_CLONE|unix.OPEN_TREE_CLOEXEC|unix.AT_NO_AUTOMOUNT))
 	if err != nil {
-		return fmt.Errorf("open source %s: %w", stagingPath, err)
+		return fmt.Errorf("open_tree %s: %w", stagingPath, err)
 	}
 	defer unix.Close(sourceFd)
-	sourcePath := fmt.Sprintf("/proc/self/fd/%d", sourceFd)
 
 	// Save our current mount namespace so we can restore it.
 	origNS, err := os.Open("/proc/self/ns/mnt")
@@ -387,13 +399,13 @@ func remountViaSetns(containerPID int, containerMountPath, stagingPath string, r
 		glog.V(4).Infof("container remount: umount %s in PID %d: %v (may already be unmounted)", containerMountPath, containerPID, umountErr)
 	}
 
-	// Bind-mount the staging path into the container by referring to
-	// the pre-setns FD via /proc/self/fd/N. The kernel resolves the
-	// magic link to the inode we opened in the CSI driver's mount
-	// namespace, so the bind succeeds even though the container's
-	// filesystem has no /var/lib/kubelet directory of its own.
-	if err := unix.Mount(sourcePath, containerMountPath, "", unix.MS_BIND, ""); err != nil {
-		return fmt.Errorf("bind mount %s (-> %s) -> %s in container PID %d: %w", sourcePath, stagingPath, containerMountPath, containerPID, err)
+	// Move the detached mount tree (from open_tree above) onto the
+	// container's mount path. The kernel attaches the fd's mount
+	// directly without walking a source path, so this works even
+	// though /var/lib/kubelet/... is not visible inside the container.
+	if err := unix.MoveMount(sourceFd, "", unix.AT_FDCWD, containerMountPath,
+		unix.MOVE_MOUNT_F_EMPTY_PATH); err != nil {
+		return fmt.Errorf("move_mount detached source -> %s in container PID %d (source path was %s): %w", containerMountPath, containerPID, stagingPath, err)
 	}
 
 	// A bind mount created with MS_BIND ignores MS_RDONLY in the same

--- a/pkg/driver/health_monitor.go
+++ b/pkg/driver/health_monitor.go
@@ -270,20 +270,14 @@ func (ns *NodeServer) recoverVolume(volumeID string) {
 
 	glog.Infof("health monitor: recovering volume %s (%d publish paths)", volumeID, len(publishes))
 
-	// Step 1: Unmount all stale bind (publish) mounts. Surface forced
-	// cleanup errors — a leftover bind mount can fool Publish() into
-	// short-circuiting and silently claim success for a still-broken path.
-	for _, p := range publishes {
-		glog.Infof("health monitor: unmounting stale publish path %s for volume %s", p.path, volumeID)
-		if err := ns.unmountFn(p.path); err != nil {
-			glog.Warningf("health monitor: unmount publish path %s failed: %v, trying force cleanup", p.path, err)
-			if cleanupErr := mount.CleanupMountPoint(p.path, mountutil, true); cleanupErr != nil {
-				glog.Errorf("health monitor: force cleanup of publish path %s for volume %s also failed: %v", p.path, volumeID, cleanupErr)
-			}
-		}
-	}
+	// Re-stage first, before touching the publish bind mounts. If any of
+	// the re-stage steps fail the publish bind mounts remain in place
+	// (still broken, but no worse than before recovery), so kubelet does
+	// not see a node where the pod's volume mount has simply disappeared
+	// while recovery flails. The next sweep can retry. Only after a fresh
+	// staging is in place do we tear down and rebuild the publish binds.
 
-	// Step 2: Tear down the FUSE mount via the mount manager so its
+	// Step 1: Tear down the FUSE mount via the mount manager so its
 	// internal state is cleared before we re-stage. cleanupStagingFn
 	// only runs a host-level mountutil.Unmount + RemoveAll, which
 	// leaves the manager believing the volume is still mounted; the
@@ -303,18 +297,33 @@ func (ns *NodeServer) recoverVolume(volumeID string) {
 		}
 	}
 
-	// Step 3: Clean up stale staging path
+	// Step 2: Clean up stale staging path
 	if err := ns.cleanupStagingFn(stagingPath); err != nil {
 		glog.Errorf("health monitor: failed to cleanup stale staging for volume %s: %v", volumeID, err)
 		return
 	}
 
-	// Step 4: Re-stage the volume with a fresh FUSE mount. stageNewVolume
+	// Step 3: Re-stage the volume with a fresh FUSE mount. stageNewVolume
 	// populates volContext/readOnly on the new Volume for us.
 	newVol, err := ns.stageNewVolume(volumeID, stagingPath, vol.volContext, vol.readOnly)
 	if err != nil {
 		glog.Errorf("health monitor: failed to re-stage volume %s: %v", volumeID, err)
 		return
+	}
+
+	// Step 4: Tear down each stale publish bind mount so the follow-up
+	// Publish() does not short-circuit on the leftover mount. We do this
+	// only now that re-staging has succeeded — running it earlier would
+	// leave kubelet seeing the publish paths empty if any of the
+	// re-stage steps above failed.
+	for _, p := range publishes {
+		glog.Infof("health monitor: unmounting stale publish path %s for volume %s", p.path, volumeID)
+		if err := ns.unmountFn(p.path); err != nil {
+			glog.Warningf("health monitor: unmount publish path %s failed: %v, trying force cleanup", p.path, err)
+			if cleanupErr := mount.CleanupMountPoint(p.path, mountutil, true); cleanupErr != nil {
+				glog.Errorf("health monitor: force cleanup of publish path %s for volume %s also failed: %v", p.path, volumeID, cleanupErr)
+			}
+		}
 	}
 
 	// Step 5: Re-bind all publish paths. Track failures and successes
@@ -350,9 +359,18 @@ func (ns *NodeServer) recoverVolume(volumeID string) {
 	// publish whose host side is healthy but whose containers still see
 	// the old mount would never be picked up by retryPublishPaths on
 	// later sweeps.
-	if oldDevice != "" {
-		for _, p := range recovered {
+	//
+	// If we were unable to capture the old device (e.g. the weed mount
+	// process exited and its wait() goroutine had already unmounted the
+	// staging path before recoverVolume ran), fall back to the scan-based
+	// remount that detects ENOTCONN/EIO mounts inside the pod and
+	// replaces them. Otherwise pods would be left with a "transport
+	// endpoint is not connected" mount even after a successful recovery.
+	for _, p := range recovered {
+		if oldDevice != "" {
 			remountInContainers(p.path, stagingPath, oldDevice, p.readOnly)
+		} else {
+			remountStaleFuseInContainers(p.path, stagingPath, p.readOnly)
 		}
 	}
 

--- a/pkg/driver/health_monitor.go
+++ b/pkg/driver/health_monitor.go
@@ -268,6 +268,24 @@ func (ns *NodeServer) recoverVolume(volumeID string) {
 		return true
 	})
 
+	// If the staging mount is already gone (e.g. the weed mount
+	// process exited and its wait() goroutine ran kubeMounter.Unmount
+	// before this sweep), fall back to a publish path's bind mount
+	// for the device. The publish bind targets the same FUSE device
+	// as staging, so any one is sufficient to identify the stale
+	// mount inside containers. Using a device-keyed remount keeps
+	// the rest of the function from having to scan for "any stale
+	// FUSE in the pod", which would risk replacing a different
+	// volume's mount when a pod uses several CSI volumes.
+	if oldDevice == "" {
+		for _, p := range publishes {
+			if d, err := getMountDevice(p.path); err == nil && d != "" {
+				oldDevice = d
+				break
+			}
+		}
+	}
+
 	glog.Infof("health monitor: recovering volume %s (%d publish paths)", volumeID, len(publishes))
 
 	// Re-stage first, before touching the publish bind mounts. If any of
@@ -316,14 +334,26 @@ func (ns *NodeServer) recoverVolume(volumeID string) {
 	// only now that re-staging has succeeded — running it earlier would
 	// leave kubelet seeing the publish paths empty if any of the
 	// re-stage steps above failed.
+	//
+	// Track which publishes were *actually* unmounted. Volume.Publish
+	// short-circuits on any pre-existing mount at the target — without
+	// this guard a stale bind we could not tear down would silently
+	// satisfy Publish and the recovery would falsely report success
+	// against the dead FUSE.
+	unmounted := make(map[string]bool, len(publishes))
 	for _, p := range publishes {
 		glog.Infof("health monitor: unmounting stale publish path %s for volume %s", p.path, volumeID)
-		if err := ns.unmountFn(p.path); err != nil {
+		if err := ns.unmountFn(p.path); err == nil {
+			unmounted[p.path] = true
+			continue
+		} else {
 			glog.Warningf("health monitor: unmount publish path %s failed: %v, trying force cleanup", p.path, err)
-			if cleanupErr := mount.CleanupMountPoint(p.path, mountutil, true); cleanupErr != nil {
-				glog.Errorf("health monitor: force cleanup of publish path %s for volume %s also failed: %v", p.path, volumeID, cleanupErr)
-			}
 		}
+		if cleanupErr := mount.CleanupMountPoint(p.path, mountutil, true); cleanupErr != nil {
+			glog.Errorf("health monitor: force cleanup of publish path %s for volume %s also failed: %v; skipping re-publish to avoid Publish() falsely satisfying the stale mount", p.path, volumeID, cleanupErr)
+			continue
+		}
+		unmounted[p.path] = true
 	}
 
 	// Step 5: Re-bind all publish paths. Track failures and successes
@@ -331,6 +361,16 @@ func (ns *NodeServer) recoverVolume(volumeID string) {
 	// publishes that did recover even if some others failed.
 	var failed, recovered []publishInfo
 	for _, p := range publishes {
+		// Always re-register the path so retryPublishPaths can see it
+		// on the next sweep and so Unpublish can tear it down correctly.
+		newVol.AddPublishPath(p.path, p.readOnly)
+		if !unmounted[p.path] {
+			// The stale bind is still in place; re-binding now would
+			// be a Publish() no-op against the dead FUSE. Defer to
+			// the next sweep's retryPublishPaths.
+			failed = append(failed, p)
+			continue
+		}
 		glog.Infof("health monitor: re-publishing %s for volume %s", p.path, volumeID)
 		if err := newVol.Publish(stagingPath, p.path, p.readOnly); err != nil {
 			glog.Errorf("health monitor: failed to re-publish %s for volume %s: %v", p.path, volumeID, err)
@@ -338,9 +378,6 @@ func (ns *NodeServer) recoverVolume(volumeID string) {
 		} else {
 			recovered = append(recovered, p)
 		}
-		// Always re-register the path so retryPublishPaths can see it
-		// on the next sweep and so Unpublish can tear it down correctly.
-		newVol.AddPublishPath(p.path, p.readOnly)
 	}
 
 	// Step 6: Replace the volume in the map
@@ -360,17 +397,20 @@ func (ns *NodeServer) recoverVolume(volumeID string) {
 	// the old mount would never be picked up by retryPublishPaths on
 	// later sweeps.
 	//
-	// If we were unable to capture the old device (e.g. the weed mount
-	// process exited and its wait() goroutine had already unmounted the
-	// staging path before recoverVolume ran), fall back to the scan-based
-	// remount that detects ENOTCONN/EIO mounts inside the pod and
-	// replaces them. Otherwise pods would be left with a "transport
-	// endpoint is not connected" mount even after a successful recovery.
-	for _, p := range recovered {
-		if oldDevice != "" {
+	// Only the device-keyed remount is used here so we never touch a
+	// FUSE mount that belongs to a different volume in the same pod.
+	// oldDevice is set from the staging path or, if the staging mount
+	// was already gone, from a publish path's bind mount (both target
+	// the same FUSE device). If we still have no oldDevice — both
+	// staging and every publish bind have been unmounted at OS level
+	// before recovery ran — we cannot safely identify the stale entry
+	// without risking a cross-volume remount, so we log and skip; the
+	// next sweep can retry.
+	if oldDevice == "" {
+		glog.Warningf("health monitor: skipping container-side remount for volume %s: no device captured for the old FUSE mount; pods may still see a stale mount until the next sweep", volumeID)
+	} else {
+		for _, p := range recovered {
 			remountInContainers(p.path, stagingPath, oldDevice, p.readOnly)
-		} else {
-			remountStaleFuseInContainers(p.path, stagingPath, p.readOnly)
 		}
 	}
 

--- a/pkg/driver/health_monitor.go
+++ b/pkg/driver/health_monitor.go
@@ -205,12 +205,21 @@ func (ns *NodeServer) retryPublishPaths(volumeID string) {
 		}
 		glog.Warningf("health monitor: re-binding publish path %s for volume %s", path, volumeID)
 		// Clear any stale/corrupt mount first so Publish's checkMount
-		// does not short-circuit on a leftover mount.
+		// does not short-circuit on a leftover mount. Volume.Publish
+		// returns success on a pre-existing mount at the target — if
+		// we cannot tear it down, calling Publish would falsely claim
+		// to have re-bound onto the dead FUSE. Defer to the next
+		// sweep instead.
+		unmountedOK := true
 		if err := ns.unmountFn(path); err != nil {
 			glog.Warningf("health monitor: unmount of publish path %s for volume %s failed: %v, trying force cleanup", path, volumeID, err)
 			if cleanupErr := mount.CleanupMountPoint(path, mountutil, true); cleanupErr != nil {
-				glog.Errorf("health monitor: force cleanup of publish path %s for volume %s also failed: %v", path, volumeID, cleanupErr)
+				glog.Errorf("health monitor: force cleanup of publish path %s for volume %s also failed: %v; skipping re-publish to avoid Publish() falsely satisfying the stale mount", path, volumeID, cleanupErr)
+				unmountedOK = false
 			}
+		}
+		if !unmountedOK {
+			return true
 		}
 		if err := vol.Publish(vol.StagedPath, path, readOnly); err != nil {
 			glog.Errorf("health monitor: failed to re-bind publish path %s for volume %s: %v", path, volumeID, err)
@@ -219,7 +228,7 @@ func (ns *NodeServer) retryPublishPaths(volumeID string) {
 		glog.Infof("health monitor: successfully re-bound publish path %s for volume %s", path, volumeID)
 
 		// Fix any stale mounts inside the pod containers (same
-		// rationale as recoverVolume step 6).
+		// rationale as recoverVolume step 7).
 		remountStaleFuseInContainers(path, vol.StagedPath, readOnly)
 		return true
 	})
@@ -401,13 +410,20 @@ func (ns *NodeServer) recoverVolume(volumeID string) {
 	// FUSE mount that belongs to a different volume in the same pod.
 	// oldDevice is set from the staging path or, if the staging mount
 	// was already gone, from a publish path's bind mount (both target
-	// the same FUSE device). If we still have no oldDevice — both
-	// staging and every publish bind have been unmounted at OS level
-	// before recovery ran — we cannot safely identify the stale entry
-	// without risking a cross-volume remount, so we log and skip; the
-	// next sweep can retry.
+	// the same FUSE device).
+	//
+	// If we still have no oldDevice — both staging and every publish
+	// bind have already been unmounted at OS level before recovery ran
+	// — we cannot safely identify the stale entry without risking a
+	// cross-volume remount. There is also no automatic retry path that
+	// will fix this on a later sweep: hasUnhealthyPublishPath only
+	// inspects the host bind mount, which is now healthy, so the next
+	// sweep will see nothing to do. The pod's containers will keep
+	// returning "transport endpoint is not connected" until the pod is
+	// restarted (or the kubelet recreates the pod, e.g. via a liveness
+	// probe). Log loudly so an operator notices.
 	if oldDevice == "" {
-		glog.Warningf("health monitor: skipping container-side remount for volume %s: no device captured for the old FUSE mount; pods may still see a stale mount until the next sweep", volumeID)
+		glog.Errorf("health monitor: container-side remount for volume %s could not run — no device captured for the old FUSE mount; affected pods will need to be restarted manually because hasUnhealthyPublishPath only sees the (now healthy) host bind", volumeID)
 	} else {
 		for _, p := range recovered {
 			remountInContainers(p.path, stagingPath, oldDevice, p.readOnly)

--- a/pkg/driver/health_monitor_test.go
+++ b/pkg/driver/health_monitor_test.go
@@ -297,6 +297,86 @@ func TestHealthMonitorAbortsOnUnmounterError(t *testing.T) {
 	}
 }
 
+// TestHealthMonitorPreservesPublishesOnReStageFailure pins the
+// recovery ordering required by #261's stress findings: publish bind
+// mounts must NOT be torn down until re-staging has succeeded.
+//
+// Before this PR, recoverVolume unmounted every publish path first,
+// then attempted the re-stage. If any of (unmount manager, cleanup,
+// stageNewVolume) failed, the recovery returned with the publish
+// binds gone and no replacement — kubelet then saw bare empty
+// publish paths ("no mounts in the pods" in kvaster's report).
+//
+// Now publish-bind teardown happens only after stageNewVolume
+// succeeds, so a failed re-stage leaves the (broken) binds in place
+// for the next sweep to retry.
+func TestHealthMonitorPreservesPublishesOnReStageFailure(t *testing.T) {
+	state := newFakeMountState()
+	ns := newNodeServerWithFakes(t, state)
+
+	root := t.TempDir()
+	stagingPath := filepath.Join(root, "staging")
+	publishPath := filepath.Join(root, "pod", "mount")
+	volCtx := map[string]string{"collection": "c"}
+
+	vol, err := ns.stageNewVolume("vol-1", stagingPath, volCtx, false)
+	if err != nil {
+		t.Fatalf("stageNewVolume: %v", err)
+	}
+	vol.volContext = volCtx
+	if err := vol.Publish(stagingPath, publishPath, false); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	vol.AddPublishPath(publishPath, false)
+	ns.volumes.Store("vol-1", vol)
+
+	bindMountsBefore := state.bindMountCalls
+	unmountsBefore := state.unmountCalls
+
+	// Make stageNewVolume fail during recovery. The first mounter
+	// factory call already happened above; flip the flag now so the
+	// recovery's call returns an error.
+	wantErr := errors.New("simulated re-stage failure")
+	ns.mounterFactory = func(volumeID string, readOnly bool, driver *SeaweedFsDriver, volContext map[string]string) (Mounter, error) {
+		return nil, wantErr
+	}
+
+	state.healthy.Store(false)
+
+	ns.checkAndRecoverVolumes()
+	ns.recoveryWg.Wait()
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+
+	// Manager-unmount + cleanup must have run (we must always tear
+	// down the dead FUSE so the next sweep can retry against fresh
+	// state) — these are the steps before re-stage in the new order.
+	if state.unstageCalls != 1 {
+		t.Errorf("expected 1 manager unmount during failed recovery, got %d", state.unstageCalls)
+	}
+	if state.cleanupCalls != 1 {
+		t.Errorf("expected 1 staging cleanup during failed recovery, got %d", state.cleanupCalls)
+	}
+	// Publish bind teardown must NOT have run — that's the bug fix.
+	if state.unmountCalls != unmountsBefore {
+		t.Errorf("publish bind mounts must not be unmounted when re-stage fails (regression of #261), got %d unmounts (expected %d)", state.unmountCalls, unmountsBefore)
+	}
+	// No new bind mounts either: re-publish never ran.
+	if state.bindMountCalls != bindMountsBefore {
+		t.Errorf("expected no new bind mounts when re-stage fails, got %d (was %d)", state.bindMountCalls, bindMountsBefore)
+	}
+	// The volume map still references the original Volume so the
+	// next sweep can retry from a known state.
+	got, ok := ns.volumes.Load("vol-1")
+	if !ok {
+		t.Fatal("volume removed from map after failed recovery")
+	}
+	if got.(*Volume) != vol {
+		t.Error("expected original volume preserved after failed recovery")
+	}
+}
+
 // TestHealthMonitorSkipsHealthyVolumes verifies the monitor does not
 // disrupt volumes whose FUSE mount is still alive.
 func TestHealthMonitorSkipsHealthyVolumes(t *testing.T) {


### PR DESCRIPTION
Stress-testing in [issue #261](https://github.com/seaweedfs/seaweedfs-csi-driver/issues/261#issuecomment-4385335896) (filer disabled for ~2 minutes; weed mount processes give up) surfaced two recovery-correctness bugs that #263's manager-state fix did not cover:

## 1. "transport endpoint is not connected" inside pods after a successful recovery

`recoverVolume` reads `oldDevice` from `/proc/self/mountinfo` at the top, then calls the manager's unmount. When the weed mount process has *already* exited on its own, its `wait()` goroutine has already done a 100 ms-delayed `kubeMounter.Unmount(target)` — so by the time `recoverVolume` runs, the staging mount is gone from `/proc/self/mountinfo` and `getMountDevice` returns empty.

Step 7's container-side remount is keyed on `oldDevice`, so it gets skipped entirely. The host bind mount is fresh, but containers still hold the old dead FUSE, and `hasUnhealthyPublishPath` only inspects the host side, so the next sweep never fixes it.

**Fix:** when `oldDevice` is empty, fall back to the existing scan-based `remountStaleFuseInContainers` which walks each container's mountinfo for `ENOTCONN`/`EIO` FUSE entries and replaces them.

## 2. "node without mounts in the pods" after a partial recovery failure

The original step 1 unmounted every publish bind, then steps 2–4 did the manager-unmount + cleanup + re-stage. If any of 2–4 failed, recovery returned with the publish binds gone and no replacement — kubelet then saw bare empty publish paths.

**Fix:** reorder so the publish-bind teardown happens only after re-staging has succeeded. If a re-stage step fails, the publish binds stay in place (still broken, but no worse than before recovery) and the next sweep can retry. New step order:

1. `vol.unmounter.Unmount()` (manager)
2. `cleanupStagingFn` (host)
3. `stageNewVolume` (fresh FUSE)
4. unmount stale publish binds — **moved here**
5. re-publish
6. replace volume in map
7. fix container-side stale mounts (with the `oldDevice`-empty fallback above)

## Test plan

- [x] `go build ./...`, `GOOS=linux go build ./...`
- [x] `go vet ./...`, `GOOS=linux go vet ./...`
- [x] Existing `pkg/driver` tests (`TestHealthMonitorRecoversStaleMount`, `TestHealthMonitorAbortsOnUnmounterError`, etc.) still compile and the assertion counts (`stageCalls`, `unstageCalls`, `cleanupCalls`, `unmountCalls`, `bindMountCalls`) are still satisfied under the new ordering.
- [ ] Reproduce the kvaster scenario in a kind cluster: pause the filer for 2 minutes, watch weed mount processes exit, then confirm: a) no pod is left with "transport endpoint is not connected", b) no pod is left with an empty publish path even if a recovery cycle aborts mid-flight.

cc @kvaster — this is the change I described in https://github.com/seaweedfs/seaweedfs-csi-driver/issues/261#issuecomment-4385444490; would appreciate a retest once #263 + this lands.