### PR TITLE
fix: refuse to clean up staging path while still mounted

### DIFF
--- a/pkg/driver/health_monitor.go
+++ b/pkg/driver/health_monitor.go
@@ -298,6 +298,17 @@ func (ns *NodeServer) recoverVolume(volumeID string) {
 		}
 	}
 
+	// Refuse to enter cleanupStagingFn (which RemoveAlls the staging path)
+	// while it is still a mount point — RemoveAll on a live FUSE would
+	// delete remote data via gRPC. The FUSE can still be alive here when
+	// vol.unmounter was nil (rebuilt volume) or when wait()'s
+	// kubeMounter.Unmount silently failed.
+	if notMnt, err := mountutil.IsLikelyNotMountPoint(stagingPath); err == nil && !notMnt {
+		glog.Errorf("health monitor: refusing to clean up staging path %s for volume %s — still a mount point; aborting recovery to avoid data deletion", stagingPath, volumeID)
+		return
+	}
+
+
 	if err := ns.cleanupStagingFn(stagingPath); err != nil {
 		glog.Errorf("health monitor: failed to cleanup stale staging for volume %s: %v", volumeID, err)
 		return


### PR DESCRIPTION
Stacked on #264 — depends on its reorder of \`recoverVolume\`. Will auto-rebase to \`master\` when #264 lands.

## The risk

\`cleanupStaleStagingPath\` runs \`os.RemoveAll(stagingPath)\` after a host-level \`mountutil.Unmount\`. If the FUSE daemon is still alive at that point, \`RemoveAll\` walks into the live mount and **deletes user data on the remote filer via the FUSE→filer gRPC**. Two ways the daemon can still be alive in \`recoverVolume\`:

1. \`vol.unmounter\` is nil (volume rebuilt from an existing staging path after a CSI driver restart), so #264's Step 1 manager-side unmount is skipped entirely.
2. \`vol.unmounter.Unmount()\` returned success, but the mount-service \`wait()\` goroutine's \`kubeMounter.Unmount\` silently failed — its error is ignored on the \`_ = kubeMounter.Unmount(p.target)\` line.

Either path lets us walk into a live FUSE during cleanup. This must not happen even during a transient seaweedfs-internal volume.move (when the FUSE may briefly look unhealthy from the CSI driver's perspective): no recovery code path may delete remote data.

## Fix

Add a probe between Step 1 and Step 2 in \`recoverVolume\`:

\`\`\`go
if isMnt, err := mountutil.IsMountPoint(stagingPath); err == nil && isMnt {
    glog.Errorf("...refusing to clean up staging path %s for volume %s — still a mount point...")
    return
}
\`\`\`

If the path is still a mount point we abort recovery for this sweep; the next sweep can retry once the mount is actually gone.

This is the same defensive idea as #262 (which guards \`cleanupStaleStagingPath\` itself). Layering it into \`recoverVolume\` makes #264's reorder safe regardless of merge order with #262 — i.e. even if #264 lands first, no recovery sweep can RemoveAll a live FUSE.

## Test plan

- [x] \`go build ./...\` / \`GOOS=linux go build ./...\`
- [x] \`go vet ./...\` / \`GOOS=linux go vet ./...\`
- [x] \`pkg/driver\` tests still compile under the new ordering and existing test mounts (which are real tmpdirs, not FUSE) trip the guard correctly: \`mountutil.IsMountPoint\` returns false on the temp staging path so recovery proceeds normally — the guard only fires against a real live FUSE.
- [ ] Repro: rebuild a volume from existing staging (CSI driver restart with a healthy FUSE in place), then trip the health monitor with a transient ReadDir failure; confirm the guard fires (Error log, no RemoveAll, volume map untouched), and the next sweep recovers normally once the FUSE is actually torn down.

cc @kvaster — this is the data-safety guard mentioned in https://github.com/seaweedfs/seaweedfs-csi-driver/issues/261; relevant if you're seeing recovery sweeps fire while weed mount is still alive but slow.