### PR TITLE
fix: preserve subPath offset when remounting recovered FUSE in containers (#271)

### DIFF
--- a/pkg/driver/container_remount_integration_test.go
+++ b/pkg/driver/container_remount_integration_test.go
@@ -193,8 +193,9 @@ func TestIntegrationRemountViaSetnsSubPath(t *testing.T) {
 		t.Fatalf("parse child PID %q: %v", string(pidBytes), err)
 	}
 
-	// Act: remount with subPath "store".
-	if err := remountViaSetns(childPID, childMountpoint, stagingDir, "store", false); err != nil {
+	// Act: remount with subPath "/store" (mountinfo root shape, with the
+	// leading slash production passes from mountInfoEntry.root).
+	if err := remountViaSetns(childPID, childMountpoint, stagingDir, "/store", false); err != nil {
 		t.Fatalf("remountViaSetns: %v", err)
 	}
 

--- a/pkg/driver/container_remount_integration_test.go
+++ b/pkg/driver/container_remount_integration_test.go
@@ -104,7 +104,7 @@ func TestIntegrationRemountViaSetns(t *testing.T) {
 	}
 
 	// --- Act: use remountViaSetns to replace the mount ---
-	if err := remountViaSetns(childPID, childMountpoint, replacementDir, false); err != nil {
+	if err := remountViaSetns(childPID, childMountpoint, replacementDir, "", false); err != nil {
 		t.Fatalf("remountViaSetns: %v", err)
 	}
 
@@ -121,6 +121,91 @@ func TestIntegrationRemountViaSetns(t *testing.T) {
 	// We should still be able to read our own files normally.
 	if _, err := os.ReadDir(root); err != nil {
 		t.Errorf("failed to read test root after remount (namespace leak?): %v", err)
+	}
+}
+
+// TestIntegrationRemountViaSetnsSubPath verifies that when a non-empty
+// subPath is supplied, remountViaSetns binds from <staging>/<subPath>
+// rather than the staging root. This is the regression guard for
+// seaweedfs/seaweedfs-csi-driver#271, where a subPath volume mount
+// silently resolved to the share root after FUSE recovery.
+func TestIntegrationRemountViaSetnsSubPath(t *testing.T) {
+	skipIfNotRoot(t)
+
+	// staging/ has a "store" subdir; only the subdir should be visible at
+	// the container mountpoint after the remount.
+	root := t.TempDir()
+	stagingDir := filepath.Join(root, "staging")
+	storeDir := filepath.Join(stagingDir, "store")
+	childMountpoint := filepath.Join(root, "childmnt")
+
+	for _, d := range []string{storeDir, childMountpoint} {
+		if err := os.MkdirAll(d, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Marker at the staging root must NOT leak through; the subdir marker
+	// is what a correct subPath bind should expose.
+	if err := os.WriteFile(filepath.Join(stagingDir, "marker"), []byte("root"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(storeDir, "marker"), []byte("instore"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	pidFile := filepath.Join(root, "child.pid")
+	readyFile := filepath.Join(root, "child.ready")
+	// The child starts with an empty mount over childMountpoint to stand
+	// in for the stale FUSE bind that recovery will replace.
+	child := exec.Command("unshare", "--mount", "--propagation", "private",
+		"sh", "-c", fmt.Sprintf(
+			`mount -t tmpfs none %s && echo $$ > %s && touch %s && sleep 60`,
+			childMountpoint, pidFile, readyFile,
+		))
+	child.SysProcAttr = &syscall.SysProcAttr{Pdeathsig: syscall.SIGKILL}
+	if err := child.Start(); err != nil {
+		t.Fatalf("start child: %v", err)
+	}
+	defer func() {
+		child.Process.Kill()
+		child.Wait()
+	}()
+
+	deadline := time.Now().Add(5 * time.Second)
+	ready := false
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(readyFile); err == nil {
+			ready = true
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if !ready {
+		t.Fatal("child did not become ready")
+	}
+
+	pidBytes, err := os.ReadFile(pidFile)
+	if err != nil {
+		t.Fatalf("read child PID: %v", err)
+	}
+	childPID, err := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
+	if err != nil {
+		t.Fatalf("parse child PID %q: %v", string(pidBytes), err)
+	}
+
+	// Act: remount with subPath "store".
+	if err := remountViaSetns(childPID, childMountpoint, stagingDir, "store", false); err != nil {
+		t.Fatalf("remountViaSetns: %v", err)
+	}
+
+	// Verify: the container mountpoint shows the subdir content, not the root.
+	markerPath := fmt.Sprintf("/proc/%d/root%s/marker", childPID, childMountpoint)
+	data, err := os.ReadFile(markerPath)
+	if err != nil {
+		t.Fatalf("read marker after subPath remount: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "instore" {
+		t.Errorf("expected 'instore' marker (subPath bind), got %q — subPath offset was dropped", got)
 	}
 }
 
@@ -172,7 +257,7 @@ func TestIntegrationRemountViaSetnsRestoresNamespaceOnFailure(t *testing.T) {
 	}
 
 	// Try to remount a path that doesn't exist in the child namespace.
-	remountErr := remountViaSetns(childPID, "/nonexistent/path/that/does/not/exist", srcDir, false)
+	remountErr := remountViaSetns(childPID, "/nonexistent/path/that/does/not/exist", srcDir, "", false)
 	if remountErr == nil {
 		t.Fatal("expected error for nonexistent target, got nil")
 	}

--- a/pkg/driver/container_remount_linux.go
+++ b/pkg/driver/container_remount_linux.go
@@ -240,9 +240,11 @@ func parseMountInfoReader(r io.Reader) ([]mountInfoEntry, error) {
 			continue
 		}
 		// Format: id parent major:minor root mountpoint opts [optional...] - fstype source superopts
+		// root and mountpoint are octal-escaped by util-linux; decode them
+		// before use in filesystem operations.
 		device := fields[2]
-		root := fields[3]
-		mountpoint := fields[4]
+		root := unescapeMountField(fields[3])
+		mountpoint := unescapeMountField(fields[4])
 
 		// Find the "-" separator to get fstype
 		sepIdx := -1
@@ -266,6 +268,35 @@ func parseMountInfoReader(r io.Reader) ([]mountInfoEntry, error) {
 	}
 	return entries, scanner.Err()
 }
+
+// unescapeMountField decodes the octal escape sequences util-linux uses
+// for the root and mountpoint fields of /proc/<pid>/mountinfo. Space
+// (\040), tab (\011), newline (\012) and backslash (\134) are written as
+// three-digit octal so each field stays whitespace-free and splittable, so
+// any '\' in the field begins such a sequence. Unknown sequences are left
+// verbatim. Unlike strconv.Unquote this never errors and never trips over
+// an embedded quote, so a path that fails to decode cannot silently
+// collapse to "" — which for the root field would drop the subPath offset
+// and re-introduce the share-root bind this change exists to prevent.
+func unescapeMountField(s string) string {
+	if !strings.ContainsRune(s, '\\') {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+3 < len(s) &&
+			isOctalDigit(s[i+1]) && isOctalDigit(s[i+2]) && isOctalDigit(s[i+3]) {
+			b.WriteByte((s[i+1]-'0')<<6 | (s[i+2]-'0')<<3 | (s[i+3] - '0'))
+			i += 3
+			continue
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}
+
+func isOctalDigit(c byte) bool { return c >= '0' && c <= '7' }
 
 // getMountDevice returns the "major:minor" device string for a mount
 // at the given path by parsing /proc/self/mountinfo.

--- a/pkg/driver/container_remount_linux.go
+++ b/pkg/driver/container_remount_linux.go
@@ -4,7 +4,9 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -50,17 +52,17 @@ func remountInContainers(publishPath, stagingPath, oldDevice string, readOnly bo
 	}
 
 	for _, pid := range pids {
-		mountPaths, err := findContainerMountsByDevice(pid, oldDevice)
-		if err != nil || len(mountPaths) == 0 {
+		mounts, err := findContainerMountsByDevice(pid, oldDevice)
+		if err != nil || len(mounts) == 0 {
 			continue
 		}
 
-		for _, containerMountPath := range mountPaths {
-			glog.Infof("container remount: fixing stale mount %s in container PID %d (pod %s)", containerMountPath, pid, podUID)
-			if err := remountViaSetns(pid, containerMountPath, stagingPath, readOnly); err != nil {
-				glog.Warningf("container remount: failed to remount %s in PID %d: %v", containerMountPath, pid, err)
+		for _, m := range mounts {
+			glog.Infof("container remount: fixing stale mount %s (subPath %q) in container PID %d (pod %s)", m.mountpoint, m.root, pid, podUID)
+			if err := remountViaSetns(pid, m.mountpoint, stagingPath, m.root, readOnly); err != nil {
+				glog.Warningf("container remount: failed to remount %s in PID %d: %v", m.mountpoint, pid, err)
 			} else {
-				glog.Infof("container remount: successfully remounted %s in PID %d", containerMountPath, pid)
+				glog.Infof("container remount: successfully remounted %s in PID %d", m.mountpoint, pid)
 			}
 		}
 	}
@@ -122,8 +124,8 @@ func remountStaleFuseInContainers(publishPath, stagingPath string, readOnly bool
 				continue
 			}
 
-			glog.Infof("container remount: fixing stale mount %s in container PID %d (pod %s)", e.mountpoint, pid, podUID)
-			if err := remountViaSetns(pid, e.mountpoint, stagingPath, readOnly); err != nil {
+			glog.Infof("container remount: fixing stale mount %s (subPath %q) in container PID %d (pod %s)", e.mountpoint, e.root, pid, podUID)
+			if err := remountViaSetns(pid, e.mountpoint, stagingPath, e.root, readOnly); err != nil {
 				glog.Warningf("container remount: failed to remount %s in PID %d: %v", e.mountpoint, pid, err)
 			} else {
 				glog.Infof("container remount: successfully remounted %s in PID %d", e.mountpoint, pid)
@@ -204,7 +206,13 @@ func findContainerPIDsForPod(podUID string) ([]int, error) {
 
 // mountInfoEntry holds a parsed line from /proc/<pid>/mountinfo.
 type mountInfoEntry struct {
-	device     string // "major:minor"
+	device string // "major:minor"
+	// root is the pathname of the directory in the filesystem that forms
+	// the root of this mount (mountinfo field 4). For a bind created from
+	// a volumeMount subPath it is the subPath offset (e.g. "/store"); for
+	// a whole-filesystem mount it is "/". Preserving it is what keeps a
+	// subPath mount pointing at <staging>/<subPath> after a remount.
+	root       string
 	mountpoint string
 	fstype     string
 }
@@ -217,9 +225,15 @@ func parseMountInfo(pid int) ([]mountInfoEntry, error) {
 		return nil, err
 	}
 	defer f.Close()
+	return parseMountInfoReader(f)
+}
 
+// parseMountInfoReader parses mountinfo-formatted content. Split out from
+// parseMountInfo so the field parsing (including the subPath-bearing root
+// field) can be unit-tested without a live /proc.
+func parseMountInfoReader(r io.Reader) ([]mountInfoEntry, error) {
 	var entries []mountInfoEntry
-	scanner := bufio.NewScanner(f)
+	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		fields := strings.Fields(scanner.Text())
 		if len(fields) < 7 {
@@ -227,6 +241,7 @@ func parseMountInfo(pid int) ([]mountInfoEntry, error) {
 		}
 		// Format: id parent major:minor root mountpoint opts [optional...] - fstype source superopts
 		device := fields[2]
+		root := fields[3]
 		mountpoint := fields[4]
 
 		// Find the "-" separator to get fstype
@@ -244,6 +259,7 @@ func parseMountInfo(pid int) ([]mountInfoEntry, error) {
 
 		entries = append(entries, mountInfoEntry{
 			device:     device,
+			root:       root,
 			mountpoint: mountpoint,
 			fstype:     fstype,
 		})
@@ -276,20 +292,22 @@ func getMountDevice(mountPath string) (string, error) {
 // findContainerMountsByDevice finds all mounts inside a container's
 // mount namespace whose device matches oldDevice and whose fstype is
 // FUSE. A single PVC can appear at multiple mount points in the same
-// container (e.g. subPath mounts), so all matches are returned.
-func findContainerMountsByDevice(pid int, oldDevice string) ([]string, error) {
+// container (e.g. a plain mount plus one or more subPath mounts), so all
+// matches are returned. Each entry carries its root (subPath offset) so
+// the remount can re-create the bind from the correct subdirectory.
+func findContainerMountsByDevice(pid int, oldDevice string) ([]mountInfoEntry, error) {
 	entries, err := parseMountInfo(pid)
 	if err != nil {
 		return nil, err
 	}
 
-	var mountpoints []string
+	var matches []mountInfoEntry
 	for _, e := range entries {
 		if e.device == oldDevice && isFuseFS(e.fstype) {
-			mountpoints = append(mountpoints, e.mountpoint)
+			matches = append(matches, e)
 		}
 	}
-	return mountpoints, nil
+	return matches, nil
 }
 
 // isFuseFS returns true if the fstype indicates a FUSE filesystem mount.
@@ -317,9 +335,17 @@ func isStaleMount(err error) bool {
 // inside the container's mount namespace because it resides on the
 // host filesystem under the kubelet directory tree.
 //
+// subPath is the mountinfo root of the stale mount being replaced. When
+// the volumeMount used a subPath, the original bind was offset into a
+// subdirectory of the FUSE filesystem (e.g. "/store"), so the fresh bind
+// must come from <stagingPath>/<subPath> rather than the share root.
+// Otherwise a subPath mount silently resolves to the root after recovery.
+// "" or "/" mean a whole-filesystem mount and bind stagingPath directly.
+// See seaweedfs/seaweedfs-csi-driver#271.
+//
 // If readOnly is true, a second remount is performed with MS_RDONLY to
 // preserve the original read-only semantics of the volume mount.
-func remountViaSetns(containerPID int, containerMountPath, stagingPath string, readOnly bool) error {
+func remountViaSetns(containerPID int, containerMountPath, stagingPath, subPath string, readOnly bool) error {
 	// Pin this goroutine to the current OS thread for the duration of
 	// the namespace switch. No other goroutine will be scheduled on
 	// this thread, preventing accidental cross-namespace operations.
@@ -335,15 +361,23 @@ func remountViaSetns(containerPID int, containerMountPath, stagingPath string, r
 		return fmt.Errorf("unshare CLONE_FS: %w", err)
 	}
 
+	// Re-create the bind from the same subdirectory the stale mount was
+	// offset into. For a subPath volumeMount this is <staging>/<subPath>;
+	// for a plain mount subPath is "" or "/" and we bind the share root.
+	source := stagingPath
+	if subPath != "" && subPath != "/" {
+		source = filepath.Join(stagingPath, subPath)
+	}
+
 	// open_tree the source BEFORE setns so we have an fd we can
 	// move_mount into the container's namespace. A path-based bind
 	// after setns fails with ENOENT — the staging path lives only in
 	// the driver pod's namespace, and /proc/self/fd/N re-walks the
 	// original path string in the current namespace. Requires Linux 5.2+.
-	sourceFd, err := unix.OpenTree(unix.AT_FDCWD, stagingPath,
+	sourceFd, err := unix.OpenTree(unix.AT_FDCWD, source,
 		uint(unix.OPEN_TREE_CLONE|unix.OPEN_TREE_CLOEXEC|unix.AT_NO_AUTOMOUNT))
 	if err != nil {
-		return fmt.Errorf("open_tree %s: %w", stagingPath, err)
+		return fmt.Errorf("open_tree %s: %w", source, err)
 	}
 	defer unix.Close(sourceFd)
 
@@ -387,7 +421,7 @@ func remountViaSetns(containerPID int, containerMountPath, stagingPath string, r
 
 	if err := unix.MoveMount(sourceFd, "", unix.AT_FDCWD, containerMountPath,
 		unix.MOVE_MOUNT_F_EMPTY_PATH); err != nil {
-		return fmt.Errorf("move_mount detached source -> %s in container PID %d (source path was %s): %w", containerMountPath, containerPID, stagingPath, err)
+		return fmt.Errorf("move_mount detached source -> %s in container PID %d (source path was %s): %w", containerMountPath, containerPID, source, err)
 	}
 
 	// A bind mount created with MS_BIND ignores MS_RDONLY in the same

--- a/pkg/driver/container_remount_test.go
+++ b/pkg/driver/container_remount_test.go
@@ -138,6 +138,49 @@ func TestParseMountInfoReaderCapturesRoot(t *testing.T) {
 	}
 }
 
+// TestParseMountInfoReaderUnescapesOctal verifies that octal escapes in
+// the root and mountpoint fields (util-linux escapes space/tab/newline/
+// backslash) are decoded, so a subPath containing a space binds the right
+// subdirectory after recovery instead of failing or dropping the offset.
+func TestParseMountInfoReaderUnescapesOctal(t *testing.T) {
+	// subPath "my store" -> root "/my\040store"; mountpoint also has a space.
+	content := "200 50 0:55 /my\\040store /var/lib/kubelet/pods/uid/a\\040b rw,relatime - fuse.seaweedfs seaweedfs rw\n"
+	entries, err := parseMountInfoReader(strings.NewReader(content))
+	if err != nil {
+		t.Fatalf("parseMountInfoReader: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].root != "/my store" {
+		t.Errorf("root = %q, want %q", entries[0].root, "/my store")
+	}
+	if entries[0].mountpoint != "/var/lib/kubelet/pods/uid/a b" {
+		t.Errorf("mountpoint = %q, want %q", entries[0].mountpoint, "/var/lib/kubelet/pods/uid/a b")
+	}
+}
+
+func TestUnescapeMountField(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"/", "/"},
+		{"/store", "/store"},
+		{"/my\\040store", "/my store"},        // space
+		{"/a\\011b", "/a\tb"},                  // tab
+		{"/a\\012b", "/a\nb"},                  // newline
+		{"/a\\134b", "/a\\b"},                  // backslash
+		{"/a\\040b\\040c", "/a b c"},           // multiple
+		{"/trailing\\04", "/trailing\\04"},     // incomplete escape left verbatim
+		{"/not\\888escape", "/not\\888escape"}, // non-octal digits left verbatim
+	}
+	for _, tt := range tests {
+		if got := unescapeMountField(tt.in); got != tt.want {
+			t.Errorf("unescapeMountField(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
 func TestIsFuseFS(t *testing.T) {
 	tests := []struct {
 		fstype string

--- a/pkg/driver/container_remount_test.go
+++ b/pkg/driver/container_remount_test.go
@@ -5,6 +5,7 @@ package driver
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -101,6 +102,39 @@ func TestParseMountInfoFromFile(t *testing.T) {
 	}
 	if !isFuseFS(entries[3].fstype) {
 		t.Error("fuse should be fuse")
+	}
+}
+
+// TestParseMountInfoReaderCapturesRoot verifies the mountinfo root field
+// (field 4, the subPath offset) is parsed. Regression guard for #271:
+// dropping this field is what made subPath mounts re-bind to the share
+// root after FUSE recovery.
+func TestParseMountInfoReaderCapturesRoot(t *testing.T) {
+	// Two binds of the same FUSE device: a plain mount (root "/") and a
+	// subPath mount (root "/store").
+	content := `100 50 0:55 / /var/lib/kubelet/pods/uid/volumes/kubernetes.io~csi/pv/mount rw,relatime - fuse.seaweedfs seaweedfs rw,user_id=0,group_id=0
+101 50 0:55 /store /var/lib/kubelet/pods/uid/volume-subpaths/pv/ctr/0 rw,nosuid,nodev,relatime - fuse.seaweedfs seaweedfs rw,user_id=0,group_id=0
+`
+	entries, err := parseMountInfoReader(strings.NewReader(content))
+	if err != nil {
+		t.Fatalf("parseMountInfoReader: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+	if entries[0].root != "/" {
+		t.Errorf("plain mount: root = %q, want %q", entries[0].root, "/")
+	}
+	if entries[1].root != "/store" {
+		t.Errorf("subPath mount: root = %q, want %q", entries[1].root, "/store")
+	}
+	for i, e := range entries {
+		if e.device != "0:55" {
+			t.Errorf("entry %d: device = %q, want 0:55", i, e.device)
+		}
+		if !isFuseFS(e.fstype) {
+			t.Errorf("entry %d: fstype %q not recognized as fuse", i, e.fstype)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #271 — `subPath` volume mounts silently re-resolve to the share **root** after the health monitor recovers a dead `weed mount`, and a later container restart then loops on `CreateContainerConfigError`.

The reporter's "State (1) — silent wrong subdir" is a real bug, but in our **own** container-remount self-heal path (added for #261/#262/#263), not in kubelet as the issue speculates.

## Root cause

When the health monitor recovers a volume it re-binds the FUSE mount inside each affected pod container via `setns(2)` + `open_tree(2)` + `move_mount(2)` (`remountViaSetns`). The bind **source was always the staging root** (`stagingPath`).

For a `volumeMount` that uses a `subPath`, the container's original bind is offset into a subdirectory of the FUSE filesystem (e.g. `/store`). The remount discarded that offset, so after recovery the container had a *live* FUSE mount pointing at `<share>` instead of `<share>/<subPath>` — exactly the reported `findmnt … :/data/nfs/...` with the missing `[/store]` suffix (and the tell-tale `nosuid,nodev` flags from our driver's bind rather than kubelet's).

The offset is recoverable without the CSI request: it's the **mountinfo `root` field (field 4)** of the stale container mount, which `parseMountInfo` was dropping.

## Change

- `parseMountInfo` now captures the `root` field (`mountInfoEntry.root`); split out `parseMountInfoReader` so parsing is unit-testable without a live `/proc`.
- `findContainerMountsByDevice` returns full entries so each match carries its `root`.
- `remountViaSetns` takes a `subPath` arg and binds from `<staging>/<subPath>` when it's non-empty / not `/` (plain mounts unchanged).
- Both recovery paths (`remountInContainers`, `remountStaleFuseInContainers`) thread the per-mount `root` through.

This requires no knowledge of the `subPath` from the CSI `NodePublishVolume` request (kubelet owns that) — it's read back from the live container mountinfo.

## Tests

- **Unit:** `TestParseMountInfoReaderCapturesRoot` — asserts `/` for a plain mount and `/store` for a subPath bind.
- **Integration** (`-tags integration`, root): `TestIntegrationRemountViaSetnsSubPath` — creates a child mount namespace, runs the real `setns`/`move_mount` with `subPath="store"`, and asserts the container mountpoint exposes the subdir marker, not the root marker (would fail before this change).

```
ok  github.com/seaweedfs/seaweedfs-csi-driver/pkg/driver           # unit
--- PASS: TestIntegrationRemountViaSetnsSubPath                    # privileged container
```

## Notes

- The reporter ran v1.4.13, which already has the container-remount code (landed in v1.4.9), so a version bump alone does not fix their scenario — this does.
- "State (2)" (`CreateContainerConfigError` loop) on a container-only restart is a kubelet-side symptom largely outside the driver's control; preserving the offset (State 1) is the part the driver can own and is what this PR fixes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Remount behavior for container FUSE mounts now preserves subPath (mount-root) semantics so bind/remount operations target the correct subdirectory and avoid leaking parent staging files.

* **Tests**
  * New integration and unit tests added to validate subPath handling, parsing/unescaping of mount fields, and remount behavior across container mount namespaces.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seaweedfs/seaweedfs-csi-driver/pull/272?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->