### PR TITLE
nomad: add CSI controller example so volume create works

### DIFF
--- a/deploy/nomad/README.md
+++ b/deploy/nomad/README.md
@@ -24,11 +24,28 @@ Seaweedfs filer will be available on http://seaweedfs-filer.service.consul:8888/
 
 ## Running CSI
 
+The CSI driver is split into two components that register under the same
+`csi_plugin` id (`seaweedfs`):
+
+ - **controller** (`seaweedfs-csi-controller.hcl`) — a single `service` job that
+   implements the volume lifecycle RPCs. Nomad calls it for `nomad volume create`
+   / `nomad volume delete`. It only talks to the filer.
+ - **node** (`seaweedfs-csi.hcl`) — a `system` job that runs on every worker and
+   stages/publishes volumes into allocations, using the `seaweedfs-mount`
+   sidecar over a shared unix socket.
+
+You need **both** running. With only the node plugin, `nomad volume create`
+fails with `plugin has no controller`.
+
 ```shell
 export NOMAD_ADDR=http://nomad.service.consul:4646
 
-# Start CSI plugin
+# Start CSI controller (one instance) and node (one per worker)
+nomad run seaweedfs-csi-controller.hcl
 nomad run seaweedfs-csi.hcl
+
+# Wait until the plugin reports a healthy controller and the expected node count
+nomad plugin status seaweedfs
 
 # Create volume
 nomad volume create example-seaweedfs-volume.hcl
@@ -36,3 +53,8 @@ nomad volume create example-seaweedfs-volume.hcl
 # Start sample app
 nomad run example-seaweedfs-app.hcl
 ```
+
+> If you only run the node plugin (no controller), you cannot `nomad volume
+> create`. Instead, pre-create the bucket/directory in SeaweedFS yourself and
+> `nomad volume register example-seaweedfs-volume.hcl` to register the existing
+> volume.

--- a/deploy/nomad/seaweedfs-csi-controller.hcl
+++ b/deploy/nomad/seaweedfs-csi-controller.hcl
@@ -1,0 +1,50 @@
+# The CSI controller implements the volume lifecycle RPCs (CreateVolume,
+# DeleteVolume, ExpandVolume, ...). Nomad calls the controller when you run
+# `nomad volume create` / `nomad volume delete`. Without a controller plugin
+# registered, `nomad volume create` fails with:
+#   Error creating volume: Unexpected response code: 500 (rpc error: plugin has no controller)
+#
+# The controller only talks to the filer (it creates/removes the bucket or
+# directory backing the volume), so unlike the node plugin it does NOT need the
+# seaweedfs-mount sidecar, host volumes, bidirectional mount propagation, or
+# privileged mode. A single instance is enough; run it as a `service` job.
+#
+# The csi_plugin.id ("seaweedfs") MUST match the id used by the node job
+# (seaweedfs-csi.hcl) so Nomad treats them as one logical plugin with both a
+# controller and nodes.
+job "seaweedfs-csi-controller" {
+  datacenters = ["dc1"]
+  type        = "service"
+  priority    = 90
+
+  group "controller" {
+    count = 1
+
+    task "plugin" {
+      driver = "docker"
+
+      config {
+        image        = "chrislusf/seaweedfs-csi-driver:v1.3.9"
+        force_pull   = true
+        network_mode = "host"
+        args = [
+          "--endpoint=unix:///csi-sock/csi.sock",
+          "--filer=seaweedfs-filer.service.consul:8888",
+          "--components=controller",
+        ]
+      }
+
+      csi_plugin {
+        id        = "seaweedfs"
+        type      = "controller"
+        mount_dir = "/csi-sock"
+      }
+
+      resources {
+        cpu        = 200
+        memory     = 128
+        memory_max = 256
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Problem

[@amadsen reported](https://github.com/seaweedfs/seaweedfs-csi-driver/commit/bc5bddabd9f33425dd6901bb3942b0368c8119d2#commitcomment-187062833) that `nomad volume create` fails with:

```
Error creating volume: Unexpected response code: 500 (rpc error: plugin has no controller)
```

Commit bc5bdda reworked the Nomad example to split out the `seaweedfs-mount` sidecar and in doing so changed the plugin from `type = "monolith"` (controller + node) to `type = "node"` only (`--components=node`). `nomad volume create` invokes the CSI **controller's** `CreateVolume` RPC, so with a node-only plugin registered Nomad has no controller to route the call to.

## Fix

- Add `deploy/nomad/seaweedfs-csi-controller.hcl` — a lightweight `service` job (`count = 1`, `--components=controller`, `csi_plugin { type = "controller" }`). It uses the **same** `csi_plugin` id (`seaweedfs`) as the node job so Nomad merges them into one logical plugin with both a controller and nodes. The controller only talks to the filer, so it needs no mount sidecar, host volumes, bidirectional propagation, or privileged mode.
- Update `deploy/nomad/README.md` to run both jobs, check `nomad plugin status seaweedfs` before creating, and document the `nomad volume register` fallback for node-only setups.

## Notes

`nomad job validate` was not run (nomad isn't installed in the dev environment); the controller HCL mirrors the existing node job structure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Nomad CSI deployment guide with clearer instructions for configuring controller and node components separately
  * Added example configuration for SeaweedFS CSI controller deployment
  * Clarified volume management workflows and requirements for different deployment scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->