### PR TITLE
[csi] fix CSI volume quota resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ For safe update set `node.updateStrategy.type: OnDelete` for manual update. Step
 
 # Testing
 
-1. Create a persistant volume claim for 5GiB with name `seaweedfs-csi-pvc` with storage class `seaweedfs-storage`. The value, 5Gib does not have any significance as for SeaweedFS the whole filesystem is mounted into the container.
+1. Create a persistent volume claim for 5GiB with name `seaweedfs-csi-pvc` and storage class `seaweedfs-storage`. The requested size is applied as a quota to the SeaweedFS collection used by the mount.
 ```
 $ kubectl apply -f deploy/kubernetes/sample-seaweedfs-pvc.yaml
 ```
@@ -139,6 +139,30 @@ $ kubectl apply -f deploy/kubernetes/sample-busybox-pod.yaml
 ```
 $ kubectl exec my-csi-app -- df -h
 ```
+
+# Capacity limits
+
+For dynamically provisioned volumes, `resources.requests.storage` is enforced by
+the SeaweedFS FUSE mount and reported by `df`. Once the mount observes that the
+quota has been reached, further writes fail with `ENOSPC`. PVC expansion updates
+the mount quota.
+
+The quota is collection-based and enforced by each CSI-managed mount, rather
+than stored as an authoritative server-side limit. By default, every dynamic
+volume gets its own collection, so its quota is isolated. If multiple volumes
+are configured to use the same `collection`, their usage is shared and they do
+not have independent per-directory quotas. Writes through another SeaweedFS
+client that does not use the quota-configured mount are not restricted by this
+CSI quota.
+
+Because enforcement is mount-side, concurrent writers on different mounts can
+briefly exceed the configured capacity before collection usage is refreshed.
+
+For statically provisioned Kubernetes volumes, the driver reads
+`spec.capacity.storage` from the PersistentVolume matching
+`spec.csi.volumeHandle`. Other orchestrators receive `volumeCapacity` from
+dynamic `CreateVolume` calls; static integrations can provide the same value in
+bytes through the volume context.
 
 # Static and dynamic provisioning
 

--- a/pkg/driver/capacity_test.go
+++ b/pkg/driver/capacity_test.go
@@ -1,0 +1,78 @@
+package driver
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestResolveVolumeCapacityUsesVolumeContextFallback(t *testing.T) {
+	ns := &NodeServer{
+		capacityFn: func(volumeID string) (int64, error) {
+			return 0, errors.New("Kubernetes API unavailable")
+		},
+	}
+
+	got, ok, err := ns.resolveVolumeCapacity("/buckets/pvc-1234", map[string]string{
+		volumeCapacityKey: "5368709120",
+	})
+	if err != nil {
+		t.Fatalf("resolveVolumeCapacity: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected volume capacity to be available")
+	}
+	if want := int64(5368709120); got != want {
+		t.Fatalf("capacity = %d, want %d", got, want)
+	}
+}
+
+func TestResolveVolumeCapacityPrefersOrchestratorValue(t *testing.T) {
+	ns := &NodeServer{
+		capacityFn: func(volumeID string) (int64, error) {
+			return 10 * 1024 * 1024 * 1024, nil
+		},
+	}
+
+	got, ok, err := ns.resolveVolumeCapacity("pvc-1234", map[string]string{
+		volumeCapacityKey: "5368709120",
+	})
+	if err != nil {
+		t.Fatalf("resolveVolumeCapacity: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected volume capacity to be available")
+	}
+	if want := int64(10 * 1024 * 1024 * 1024); got != want {
+		t.Fatalf("capacity = %d, want %d", got, want)
+	}
+}
+
+func TestResolveVolumeCapacityRejectsInvalidContextValue(t *testing.T) {
+	ns := &NodeServer{
+		capacityFn: func(volumeID string) (int64, error) {
+			return 0, errors.New("Kubernetes API unavailable")
+		},
+	}
+
+	if _, _, err := ns.resolveVolumeCapacity("pvc-1234", map[string]string{
+		volumeCapacityKey: "not-a-size",
+	}); err == nil {
+		t.Fatal("expected invalid volume capacity to return an error")
+	}
+}
+
+func TestResolveVolumeCapacityAllowsUnavailableCapacity(t *testing.T) {
+	ns := &NodeServer{
+		capacityFn: func(volumeID string) (int64, error) {
+			return 0, errors.New("Kubernetes API unavailable")
+		},
+	}
+
+	_, ok, err := ns.resolveVolumeCapacity("pvc-1234", nil)
+	if err != nil {
+		t.Fatalf("resolveVolumeCapacity: %v", err)
+	}
+	if ok {
+		t.Fatal("expected volume capacity to be unavailable")
+	}
+}

--- a/pkg/driver/controllerserver.go
+++ b/pkg/driver/controllerserver.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"path"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -83,6 +84,9 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	}
 
 	capacity := req.GetCapacityRange().GetRequiredBytes()
+	if capacity > 0 {
+		params[volumeCapacityKey] = strconv.FormatInt(capacity, 10)
+	}
 
 	if err := filer_pb.Mkdir(ctx, cs.Driver, parentDir, volumeName, nil); err != nil {
 		return nil, fmt.Errorf("error creating volume: %v", err)

--- a/pkg/driver/mounter.go
+++ b/pkg/driver/mounter.go
@@ -139,6 +139,7 @@ func (m *mountServiceMounter) buildMountArgs(targetPath, cacheDir, localSocket s
 
 	argsMap := map[string]string{
 		"collection":         collection,
+		"collectionQuotaMB":  initialCollectionQuotaMB(volumeContext[volumeCapacityKey]),
 		"filer":              strings.Join(filers, ","),
 		"filer.path":         filerPath,
 		"cacheCapacityMB":    strconv.Itoa(m.driver.CacheCapacityMB),
@@ -182,10 +183,12 @@ func (m *mountServiceMounter) buildMountArgs(targetPath, cacheDir, localSocket s
 	}
 
 	ignoredArgs := map[string]struct{}{
-		"dataLocality": {},
-		"path":         {},
-		"parentDir":    {},
-		"volumeName":   {},
+		"collectionQuotaMB": {},
+		"dataLocality":      {},
+		"path":              {},
+		"parentDir":         {},
+		"volumeName":        {},
+		volumeCapacityKey:   {},
 	}
 
 	for key, value := range volumeContext {
@@ -212,4 +215,18 @@ func (m *mountServiceMounter) buildMountArgs(targetPath, cacheDir, localSocket s
 	}
 
 	return args, nil
+}
+
+func initialCollectionQuotaMB(capacityBytes string) string {
+	capacity, err := strconv.ParseInt(capacityBytes, 10, 64)
+	if err != nil || capacity <= 1 {
+		return ""
+	}
+
+	const bytesPerMiB = int64(1024 * 1024)
+	capacityMB := capacity / bytesPerMiB
+	if capacity%bytesPerMiB != 0 {
+		capacityMB++
+	}
+	return strconv.FormatInt(capacityMB, 10)
 }

--- a/pkg/driver/mounter_test.go
+++ b/pkg/driver/mounter_test.go
@@ -1,0 +1,41 @@
+package driver
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestBuildMountArgsIncludesInitialCollectionQuota(t *testing.T) {
+	mounter := &mountServiceMounter{
+		driver:   &SeaweedFsDriver{},
+		volumeID: "/buckets/pvc-1234",
+		volContext: map[string]string{
+			volumeCapacityKey: "5368709120",
+		},
+	}
+
+	args, err := mounter.buildMountArgs(
+		"/staging",
+		"/cache",
+		"/socket",
+		[]string{"filer:8888"},
+	)
+	if err != nil {
+		t.Fatalf("buildMountArgs: %v", err)
+	}
+	if !slices.Contains(args, "-collectionQuotaMB=5120") {
+		t.Fatalf("mount args do not contain initial quota: %v", args)
+	}
+}
+
+func TestInitialCollectionQuotaMBRoundsUp(t *testing.T) {
+	if got, want := initialCollectionQuotaMB("1048577"), "2"; got != want {
+		t.Fatalf("initialCollectionQuotaMB = %q, want %q", got, want)
+	}
+}
+
+func TestInitialCollectionQuotaMBDisablesOneByteSentinel(t *testing.T) {
+	if got := initialCollectionQuotaMB("1"); got != "" {
+		t.Fatalf("initialCollectionQuotaMB = %q, want empty", got)
+	}
+}

--- a/pkg/driver/nodeserver.go
+++ b/pkg/driver/nodeserver.go
@@ -2,7 +2,9 @@ package driver
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -421,21 +423,30 @@ func (ns *NodeServer) removeVolumeMutex(volumeID string) {
 // Both the mounter and capacity lookup are resolved via NodeServer fields so
 // tests can inject fakes that do not touch the real mount service or k8s API.
 func (ns *NodeServer) stageNewVolume(volumeID, stagingTargetPath string, volContext map[string]string, readOnly bool) (*Volume, error) {
-	mounter, err := ns.mounterFactory(volumeID, readOnly, ns.Driver, volContext)
+	effectiveVolContext := cloneVolumeContext(volContext)
+	capacity, hasCapacity, err := ns.resolveVolumeCapacity(volumeID, volContext)
+	if err != nil {
+		return nil, err
+	}
+	if hasCapacity {
+		effectiveVolContext[volumeCapacityKey] = strconv.FormatInt(capacity, 10)
+	}
+
+	mounter, err := ns.mounterFactory(volumeID, readOnly, ns.Driver, effectiveVolContext)
 	if err != nil {
 		return nil, err
 	}
 
 	volume := NewVolume(volumeID, mounter, ns.Driver)
 	volume.bindMountFn = ns.bindMountFn
-	volume.volContext = volContext
+	volume.volContext = effectiveVolContext
 	volume.readOnly = readOnly
 	if err := volume.Stage(stagingTargetPath); err != nil {
 		return nil, err
 	}
 
-	// Apply quota if available
-	if capacity, err := ns.capacityFn(volumeID); err == nil {
+	// Apply quota if available.
+	if hasCapacity {
 		if err := volume.Quota(capacity); err != nil {
 			glog.Warningf("failed to apply quota for volume %s: %v", volumeID, err)
 			// Clean up the staged mount since we're returning an error
@@ -445,10 +456,36 @@ func (ns *NodeServer) stageNewVolume(volumeID, stagingTargetPath string, volCont
 			return nil, err
 		}
 	} else {
-		glog.V(4).Infof("orchestration system is not compatible with the k8s api, error is: %s", err)
+		glog.V(4).Infof("volume capacity is unavailable for %s", volumeID)
 	}
 
 	return volume, nil
+}
+
+func cloneVolumeContext(volContext map[string]string) map[string]string {
+	cloned := make(map[string]string, len(volContext)+1)
+	for key, value := range volContext {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func (ns *NodeServer) resolveVolumeCapacity(volumeID string, volContext map[string]string) (int64, bool, error) {
+	if ns.capacityFn != nil {
+		if capacity, err := ns.capacityFn(volumeID); err == nil {
+			return capacity, true, nil
+		}
+	}
+
+	value := volContext[volumeCapacityKey]
+	if value == "" {
+		return 0, false, nil
+	}
+	capacity, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || capacity < 0 {
+		return 0, false, fmt.Errorf("invalid %s value %q", volumeCapacityKey, value)
+	}
+	return capacity, true, nil
 }
 
 // isReadOnlyAccessMode checks if the given access mode is read-only.

--- a/pkg/driver/nodeserver.go
+++ b/pkg/driver/nodeserver.go
@@ -424,7 +424,7 @@ func (ns *NodeServer) removeVolumeMutex(volumeID string) {
 // tests can inject fakes that do not touch the real mount service or k8s API.
 func (ns *NodeServer) stageNewVolume(volumeID, stagingTargetPath string, volContext map[string]string, readOnly bool) (*Volume, error) {
 	effectiveVolContext := cloneVolumeContext(volContext)
-	capacity, hasCapacity, err := ns.resolveVolumeCapacity(volumeID, volContext)
+	capacity, hasCapacity, err := ns.resolveVolumeCapacity(volumeID, effectiveVolContext)
 	if err != nil {
 		return nil, err
 	}
@@ -472,9 +472,11 @@ func cloneVolumeContext(volContext map[string]string) map[string]string {
 
 func (ns *NodeServer) resolveVolumeCapacity(volumeID string, volContext map[string]string) (int64, bool, error) {
 	if ns.capacityFn != nil {
-		if capacity, err := ns.capacityFn(volumeID); err == nil {
+		capacity, err := ns.capacityFn(volumeID)
+		if err == nil {
 			return capacity, true, nil
 		}
+		glog.V(4).Infof("could not resolve capacity for volume %s from orchestrator API, falling back to volume context: %v", volumeID, err)
 	}
 
 	value := volContext[volumeCapacityKey]

--- a/pkg/driver/utils.go
+++ b/pkg/driver/utils.go
@@ -31,11 +31,13 @@ func NewNodeServer(n *SeaweedFsDriver) *NodeServer {
 	}
 
 	ns := &NodeServer{
-		Driver:           n,
-		volumeMutexes:    NewKeyMutex(),
-		stopCh:           make(chan struct{}),
-		mounterFactory:   newMounter,
-		capacityFn:       k8s.GetVolumeCapacity,
+		Driver:         n,
+		volumeMutexes:  NewKeyMutex(),
+		stopCh:         make(chan struct{}),
+		mounterFactory: newMounter,
+		capacityFn: func(volumeID string) (int64, error) {
+			return k8s.GetVolumeCapacity(n.name, volumeID)
+		},
 		isHealthyFn:      isStagingPathHealthy,
 		cleanupStagingFn: cleanupStaleStagingPath,
 		unmountFn:        mountutil.Unmount,

--- a/pkg/driver/volume.go
+++ b/pkg/driver/volume.go
@@ -14,6 +14,8 @@ import (
 	"k8s.io/mount-utils"
 )
 
+const volumeCapacityKey = "volumeCapacity"
+
 type Volume struct {
 	VolumeId   string
 	StagedPath string
@@ -27,8 +29,8 @@ type Volume struct {
 
 	// Fields for health monitor recovery
 	publishPaths sync.Map          // targetPath (string) -> bool (readOnly)
-	volContext   map[string]string  // volume context stored for re-staging
-	readOnly     bool               // FUSE-level readOnly flag
+	volContext   map[string]string // volume context stored for re-staging
+	readOnly     bool              // FUSE-level readOnly flag
 
 	// bindMountFn is used by Publish to perform the bind mount from the
 	// staging path to the pod-specific target path. Populated by the

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -20,12 +22,12 @@ func newInCluster() (*kubernetes.Clientset, error) {
 	// creates the clientset
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		panic(err.Error())
+		return nil, fmt.Errorf("failed to create in-cluster client: %v", err)
 	}
 	return clientset, nil
 }
 
-func GetVolumeCapacity(volumeId string) (int64, error) {
+func GetVolumeCapacity(driverName, volumeId string) (int64, error) {
 	client, err := newInCluster()
 	if err != nil {
 		return 0, err
@@ -33,11 +35,53 @@ func GetVolumeCapacity(volumeId string) (int64, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	if volume, err := client.CoreV1().PersistentVolumes().Get(ctx, volumeId, metav1.GetOptions{}); err != nil {
-		return 0, err
-	} else {
-		storage := volume.Spec.Capacity.Storage()
-		capacity, _ := storage.AsInt64()
-		return capacity, nil
+	return getVolumeCapacity(ctx, client, driverName, volumeId)
+}
+
+func getVolumeCapacity(ctx context.Context, client kubernetes.Interface, driverName, volumeId string) (int64, error) {
+	// Legacy dynamic volumes used the PV name as the CSI volume handle.
+	if len(validation.IsDNS1123Subdomain(volumeId)) == 0 {
+		if volume, err := client.CoreV1().PersistentVolumes().Get(ctx, volumeId, metav1.GetOptions{}); err == nil &&
+			volume.Spec.CSI != nil && volume.Spec.CSI.Driver == driverName {
+			return persistentVolumeCapacity(volume)
+		}
 	}
+
+	// Newer and statically provisioned volumes may use a filer path or another
+	// value that differs from the Kubernetes PV object name.
+	volumes, err := client.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return 0, fmt.Errorf("list persistent volumes for CSI volume handle %q: %w", volumeId, err)
+	}
+
+	var matched *corev1.PersistentVolume
+	for i := range volumes.Items {
+		volume := &volumes.Items[i]
+		if volume.Spec.CSI == nil ||
+			volume.Spec.CSI.Driver != driverName ||
+			volume.Spec.CSI.VolumeHandle != volumeId {
+			continue
+		}
+		if matched != nil {
+			return 0, fmt.Errorf("multiple persistent volumes use CSI volume handle %q", volumeId)
+		}
+		matched = volume
+	}
+	if matched == nil {
+		return 0, fmt.Errorf("persistent volume with name or CSI volume handle %q not found", volumeId)
+	}
+
+	return persistentVolumeCapacity(matched)
+}
+
+func persistentVolumeCapacity(volume *corev1.PersistentVolume) (int64, error) {
+	storage := volume.Spec.Capacity.Storage()
+	if storage == nil {
+		return 0, fmt.Errorf("persistent volume %q has no storage capacity", volume.Name)
+	}
+	capacity, ok := storage.AsInt64()
+	if !ok {
+		return 0, fmt.Errorf("persistent volume %q storage capacity does not fit in int64", volume.Name)
+	}
+	return capacity, nil
 }

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"path"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -39,16 +40,22 @@ func GetVolumeCapacity(driverName, volumeId string) (int64, error) {
 }
 
 func getVolumeCapacity(ctx context.Context, client kubernetes.Interface, driverName, volumeId string) (int64, error) {
-	// Legacy dynamic volumes used the PV name as the CSI volume handle.
-	if len(validation.IsDNS1123Subdomain(volumeId)) == 0 {
-		if volume, err := client.CoreV1().PersistentVolumes().Get(ctx, volumeId, metav1.GetOptions{}); err == nil &&
-			volume.Spec.CSI != nil && volume.Spec.CSI.Driver == driverName {
+	// Fast path: avoid listing every PersistentVolume in the cluster on each
+	// stage. Legacy dynamic volumes used the PV name directly as the CSI volume
+	// handle, while newer ones use a full filer path (e.g. "/buckets/pvc-xxxx")
+	// whose last component is still the PV name. In both cases a direct Get by
+	// that name resolves the volume, and we confirm the match before trusting it.
+	pvName := path.Base(volumeId)
+	if len(validation.IsDNS1123Subdomain(pvName)) == 0 {
+		if volume, err := client.CoreV1().PersistentVolumes().Get(ctx, pvName, metav1.GetOptions{}); err == nil &&
+			volume.Spec.CSI != nil && volume.Spec.CSI.Driver == driverName &&
+			(volume.Spec.CSI.VolumeHandle == volumeId || volume.Name == volumeId) {
 			return persistentVolumeCapacity(volume)
 		}
 	}
 
-	// Newer and statically provisioned volumes may use a filer path or another
-	// value that differs from the Kubernetes PV object name.
+	// Fallback: the handle does not map to a PV name (e.g. a static volume whose
+	// handle is an arbitrary filer path), so match by CSI volume handle instead.
 	volumes, err := client.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return 0, fmt.Errorf("list persistent volumes for CSI volume handle %q: %w", volumeId, err)

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -1,0 +1,84 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestGetVolumeCapacityByPersistentVolumeName(t *testing.T) {
+	client := fake.NewSimpleClientset(newPersistentVolume("pvc-legacy", "pvc-legacy", "5Gi"))
+
+	got, err := getVolumeCapacity(context.Background(), client, "seaweedfs-csi-driver", "pvc-legacy")
+	if err != nil {
+		t.Fatalf("getVolumeCapacity: %v", err)
+	}
+	if want := int64(5 * 1024 * 1024 * 1024); got != want {
+		t.Fatalf("capacity = %d, want %d", got, want)
+	}
+}
+
+func TestGetVolumeCapacityByCSIVolumeHandle(t *testing.T) {
+	client := fake.NewSimpleClientset(newPersistentVolume(
+		"pvc-1234",
+		"/buckets/pvc-1234",
+		"10Gi",
+	))
+
+	got, err := getVolumeCapacity(context.Background(), client, "seaweedfs-csi-driver", "/buckets/pvc-1234")
+	if err != nil {
+		t.Fatalf("getVolumeCapacity: %v", err)
+	}
+	if want := int64(10 * 1024 * 1024 * 1024); got != want {
+		t.Fatalf("capacity = %d, want %d", got, want)
+	}
+}
+
+func TestGetVolumeCapacityRejectsDuplicateHandles(t *testing.T) {
+	client := fake.NewSimpleClientset(
+		newPersistentVolume("pv-a", "/shared/path", "1Gi"),
+		newPersistentVolume("pv-b", "/shared/path", "2Gi"),
+	)
+
+	if _, err := getVolumeCapacity(context.Background(), client, "seaweedfs-csi-driver", "/shared/path"); err == nil {
+		t.Fatal("expected duplicate volume handles to return an error")
+	}
+}
+
+func TestGetVolumeCapacityScopesHandleToDriver(t *testing.T) {
+	otherDriverVolume := newPersistentVolume("other-pv", "/shared/path", "1Gi")
+	otherDriverVolume.Spec.CSI.Driver = "other.csi.example"
+	client := fake.NewSimpleClientset(
+		otherDriverVolume,
+		newPersistentVolume("seaweedfs-pv", "/shared/path", "2Gi"),
+	)
+
+	got, err := getVolumeCapacity(context.Background(), client, "seaweedfs-csi-driver", "/shared/path")
+	if err != nil {
+		t.Fatalf("getVolumeCapacity: %v", err)
+	}
+	if want := int64(2 * 1024 * 1024 * 1024); got != want {
+		t.Fatalf("capacity = %d, want %d", got, want)
+	}
+}
+
+func newPersistentVolume(name, handle, capacity string) *corev1.PersistentVolume {
+	return &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: corev1.PersistentVolumeSpec{
+			Capacity: corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse(capacity),
+			},
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				CSI: &corev1.CSIPersistentVolumeSource{
+					Driver:       "seaweedfs-csi-driver",
+					VolumeHandle: handle,
+				},
+			},
+		},
+	}
+}

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -66,6 +66,25 @@ func TestGetVolumeCapacityScopesHandleToDriver(t *testing.T) {
 	}
 }
 
+func TestGetVolumeCapacityIgnoresNameCollisionOnFastPath(t *testing.T) {
+	// A PV named "data" exists but belongs to a different volume handle. The
+	// fast-path Get by basename ("data") must not match it; the handle lookup
+	// has to fall back to the List scan and find the correct volume.
+	decoy := newPersistentVolume("data", "/some/other/path", "1Gi")
+	client := fake.NewSimpleClientset(
+		decoy,
+		newPersistentVolume("real-pv", "/mnt/data", "7Gi"),
+	)
+
+	got, err := getVolumeCapacity(context.Background(), client, "seaweedfs-csi-driver", "/mnt/data")
+	if err != nil {
+		t.Fatalf("getVolumeCapacity: %v", err)
+	}
+	if want := int64(7 * 1024 * 1024 * 1024); got != want {
+		t.Fatalf("capacity = %d, want %d", got, want)
+	}
+}
+
 func newPersistentVolume(name, handle, capacity string) *corev1.PersistentVolume {
 	return &corev1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{Name: name},


### PR DESCRIPTION
Addresses seaweedfs/seaweedfs#9936.

## What changed

- resolve Kubernetes PV capacity by CSI driver and `volumeHandle`, while preserving legacy PV-name lookup
- propagate requested capacity through `VolumeContext` for dynamic provisioning and non-Kubernetes fallback
- initialize the SeaweedFS mount with `collectionQuotaMB`, then apply the exact byte quota through the mount gRPC API
- document collection-level quota semantics and bypass/concurrency limitations
- add regression tests for full-path handles, driver scoping, fallback capacity, and mount arguments

## Root cause

Newer dynamically provisioned volumes use full filer paths such as `/buckets/pvc-...` as the CSI volume handle. The node plugin still attempted to fetch a Kubernetes PersistentVolume using that handle as the PV object name. The lookup failed and quota application was skipped. In addition, configuring quota only after mount startup could leave the mount quota polling loop inactive.

## Impact

PVC requested capacity is again applied to current full-path volume handles, static PV handles, and dynamic provisioning outside Kubernetes. Existing legacy volume handles remain supported.

## Validation

- `go test ./...`
- `go test -race ./pkg/driver ./pkg/k8s ./pkg/mountmanager`
- `go vet ./...`
- `GOOS=linux GOARCH=amd64 go test -exec=true ./pkg/driver ./pkg/k8s ./pkg/mountmanager`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PVC capacity documentation clarifying how requested sizes are applied as storage quotas and describing capacity limit behavior for both dynamically and statically provisioned volumes, including ENOSPC handling.

* **Tests**
  * Added comprehensive test coverage for volume capacity resolution and mount argument configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->