### PR TITLE
feat: support dynamic filer override via StorageClass parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ parameters:
   collection: mycollection
   replication: "011"
   diskType: "ssd"
+  filer: "seaweedfs-filer.tenant-namespace.svc:8888"
 ```
 
 There is another use case when we need to access one folder from different pods with ro/rw access.

--- a/pkg/driver/controllerserver.go
+++ b/pkg/driver/controllerserver.go
@@ -88,17 +88,29 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		params[volumeCapacityKey] = strconv.FormatInt(capacity, 10)
 	}
 
-	if err := filer_pb.Mkdir(ctx, cs.Driver, parentDir, volumeName, nil); err != nil {
+	// Parse the filer parameter from the StorageClass parameters
+	filerAddress := params["filer"]
+	clientDriver := cs.Driver
+	if filerAddress != "" {
+		clientDriver = cs.Driver.CloneWithFiler(filerAddress)
+	}
+
+	if err := filer_pb.Mkdir(ctx, clientDriver, parentDir, volumeName, nil); err != nil {
 		return nil, fmt.Errorf("error creating volume: %v", err)
 	}
 
 	glog.V(4).Infof("volume created %s at %s", requestedVolumeId, volumePath)
 
+	volumeId := volumePath
+	if filerAddress != "" {
+		volumeId = fmt.Sprintf("%s@%s", filerAddress, volumePath)
+	}
+
 	// Use full paths as VolumeID
 	// This keeps everything stateless
 	return &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
-			VolumeId:      volumePath,
+			VolumeId:      volumeId,
 			CapacityBytes: capacity,
 			VolumeContext: params,
 		},
@@ -121,6 +133,18 @@ func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 	}
 	glog.V(4).Infof("deleting volume %s", volumeId)
 
+	// Parse filer override if present in VolumeID
+	filerAddress := ""
+	if idx := strings.Index(volumeId, "@"); idx != -1 {
+		filerAddress = volumeId[:idx]
+		volumeId = volumeId[idx+1:]
+	}
+
+	clientDriver := cs.Driver
+	if filerAddress != "" {
+		clientDriver = cs.Driver.CloneWithFiler(filerAddress)
+	}
+
 	var parentDir, volumeName string
 	if path.IsAbs(volumeId) {
 		parentDir = path.Dir(volumeId)
@@ -131,8 +155,8 @@ func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 		volumeName = volumeId
 	}
 
-	if err := filer_pb.Remove(ctx, cs.Driver, parentDir, volumeName, true, true, true, false, nil); err != nil {
-		return nil, fmt.Errorf("error deleting volume %s: %v", volumeId, err)
+	if err := filer_pb.Remove(ctx, clientDriver, parentDir, volumeName, true, true, true, false, nil); err != nil {
+		return nil, fmt.Errorf("error deleting volume %s: %v", req.VolumeId, err)
 	}
 
 	return &csi.DeleteVolumeResponse{}, nil
@@ -184,6 +208,18 @@ func (cs *ControllerServer) ValidateVolumeCapabilities(ctx context.Context, req 
 		return nil, status.Error(codes.InvalidArgument, "Volume capabilities missing in request")
 	}
 
+	// Parse filer override if present in VolumeID
+	filerAddress := ""
+	if idx := strings.Index(volumeId, "@"); idx != -1 {
+		filerAddress = volumeId[:idx]
+		volumeId = volumeId[idx+1:]
+	}
+
+	clientDriver := cs.Driver
+	if filerAddress != "" {
+		clientDriver = cs.Driver.CloneWithFiler(filerAddress)
+	}
+
 	var parentDir, volumeName string
 	if path.IsAbs(volumeId) {
 		parentDir = path.Dir(volumeId)
@@ -194,13 +230,13 @@ func (cs *ControllerServer) ValidateVolumeCapabilities(ctx context.Context, req 
 		volumeName = volumeId
 	}
 
-	exists, err := filer_pb.Exists(ctx, cs.Driver, parentDir, volumeName, true)
+	exists, err := filer_pb.Exists(ctx, clientDriver, parentDir, volumeName, true)
 	if err != nil {
-		return nil, fmt.Errorf("error checking bucket %s exists: %v", volumeId, err)
+		return nil, fmt.Errorf("error checking bucket %s exists: %v", req.VolumeId, err)
 	}
 	if !exists {
 		// return an error if the volume requested does not exist
-		return nil, status.Error(codes.NotFound, fmt.Sprintf("Volume with id %s does not exist", volumeId))
+		return nil, status.Error(codes.NotFound, fmt.Sprintf("Volume with id %s does not exist", req.VolumeId))
 	}
 
 	// We currently only support RWO

--- a/pkg/driver/controllerserver_test.go
+++ b/pkg/driver/controllerserver_test.go
@@ -1,0 +1,57 @@
+package driver
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+)
+
+func TestCreateVolumeWithFilerOverride(t *testing.T) {
+	driver := NewSeaweedFsDriver("seaweedfs-csi", "global-filer:8888", "node-1", "unix://csi.sock", "", false)
+	cs := NewControllerServer(driver)
+
+	req := &csi.CreateVolumeRequest{
+		Name: "test-volume",
+		Parameters: map[string]string{
+			"filer": "custom-filer:9999",
+		},
+		VolumeCapabilities: []*csi.VolumeCapability{
+			{
+				AccessMode: &csi.VolumeCapability_AccessMode{
+					Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+				},
+			},
+		},
+	}
+
+	_, err := cs.CreateVolume(context.Background(), req)
+	if err == nil {
+		t.Fatalf("expected error from connecting to nonexistent filer, got nil")
+	}
+
+	// The error should mention the overridden filer address
+	if !strings.Contains(err.Error(), "custom-filer") {
+		t.Fatalf("expected error to contain overridden filer address 'custom-filer', got: %v", err)
+	}
+}
+
+func TestDeleteVolumeWithFilerOverride(t *testing.T) {
+	driver := NewSeaweedFsDriver("seaweedfs-csi", "global-filer:8888", "node-1", "unix://csi.sock", "", false)
+	cs := NewControllerServer(driver)
+
+	req := &csi.DeleteVolumeRequest{
+		VolumeId: "custom-filer:9999@/buckets/test-volume",
+	}
+
+	_, err := cs.DeleteVolume(context.Background(), req)
+	if err == nil {
+		t.Fatalf("expected error from connecting to nonexistent filer, got nil")
+	}
+
+	// The error should mention the overridden filer address from VolumeId
+	if !strings.Contains(err.Error(), "custom-filer") {
+		t.Fatalf("expected error to contain overridden filer address 'custom-filer', got: %v", err)
+	}
+}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -208,3 +208,9 @@ func (d *SeaweedFsDriver) AdjustedUrl(location *filer_pb.Location) string {
 func (d *SeaweedFsDriver) GetDataCenter() string {
 	return d.DataCenter
 }
+
+func (d *SeaweedFsDriver) CloneWithFiler(filer string) *SeaweedFsDriver {
+	clone := *d
+	clone.filers = pb.ServerAddresses(filer).ToAddresses()
+	return &clone
+}

--- a/pkg/driver/mounter.go
+++ b/pkg/driver/mounter.go
@@ -62,6 +62,16 @@ func (m *mountServiceMounter) Mount(target string) (Unmounter, error) {
 		filers[i] = string(address)
 	}
 
+	// Parse filer override from volumeID first
+	if idx := strings.Index(m.volumeID, "@"); idx != -1 {
+		filers = []string{m.volumeID[:idx]}
+	}
+
+	// Then allow volume context to override it if set
+	if customFiler, ok := m.volContext["filer"]; ok && customFiler != "" {
+		filers = []string{customFiler}
+	}
+
 	cacheDir := GetCacheDir(m.driver.CacheDir, m.volumeID)
 	localSocket := GetLocalSocket(m.driver.volumeSocketDir, m.volumeID)
 
@@ -101,9 +111,14 @@ func (m *mountServiceMounter) buildMountArgs(targetPath, cacheDir, localSocket s
 	}
 
 	var filerPath string
-	if path.IsAbs(m.volumeID) {
+	cleanVolumeID := m.volumeID
+	if idx := strings.Index(cleanVolumeID, "@"); idx != -1 {
+		cleanVolumeID = cleanVolumeID[idx+1:]
+	}
+
+	if path.IsAbs(cleanVolumeID) {
 		// path already resolved in controller and passed as volumeID
-		filerPath = m.volumeID
+		filerPath = cleanVolumeID
 	} else {
 		// non-absolute-path volume ID, volume is either legacy or this is a static provision
 		contextPath := volumeContext["path"]

--- a/pkg/driver/mounter_test.go
+++ b/pkg/driver/mounter_test.go
@@ -2,6 +2,7 @@ package driver
 
 import (
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -37,5 +38,38 @@ func TestInitialCollectionQuotaMBRoundsUp(t *testing.T) {
 func TestInitialCollectionQuotaMBDisablesOneByteSentinel(t *testing.T) {
 	if got := initialCollectionQuotaMB("1"); got != "" {
 		t.Fatalf("initialCollectionQuotaMB = %q, want empty", got)
+	}
+}
+
+func TestBuildMountArgsWithFilerOverride(t *testing.T) {
+	mounter := &mountServiceMounter{
+		driver:   &SeaweedFsDriver{},
+		volumeID: "custom-filer:8888@/buckets/pvc-1234",
+		volContext: map[string]string{
+			"filer": "override-filer:8888",
+		},
+	}
+
+	// 1. Verify volumeID parsing
+	cleanVolumeID := mounter.volumeID
+	if idx := strings.Index(cleanVolumeID, "@"); idx != -1 {
+		cleanVolumeID = cleanVolumeID[idx+1:]
+	}
+	if cleanVolumeID != "/buckets/pvc-1234" {
+		t.Fatalf("expected clean volume ID to be /buckets/pvc-1234, got %q", cleanVolumeID)
+	}
+
+	// 2. Verify mount args generation
+	args, err := mounter.buildMountArgs(
+		"/staging",
+		"/cache",
+		"/socket",
+		[]string{"override-filer:8888"},
+	)
+	if err != nil {
+		t.Fatalf("buildMountArgs: %v", err)
+	}
+	if !slices.Contains(args, "-filer=override-filer:8888") {
+		t.Fatalf("mount args do not contain overridden filer: %v", args)
 	}
 }


### PR DESCRIPTION
This PR introduces a new 'filer' StorageClass parameter to support dynamic routing of volume creations and FUSE mounts to different SeaweedFS filer instances in multi-tenant environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a filer override in storage settings and volume identifiers.
  * Mounting now honors filer overrides when building mount arguments.

* **Bug Fixes**
  * Volume creation, deletion, and capability checks now use the correct filer when an override is provided.
  * Volume IDs are now handled consistently when they include filer information.

* **Documentation**
  * Updated the storage provisioning example to include the filer parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->