### PR TITLE
feat: support dynamic filer override via StorageClass parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ parameters:
   collection: mycollection
   replication: "011"
   diskType: "ssd"
+  filer: "seaweedfs-filer.tenant-namespace.svc:8888"
 ```
 
 There is another use case when we need to access one folder from different pods with ro/rw access.

--- a/pkg/driver/controllerserver.go
+++ b/pkg/driver/controllerserver.go
@@ -132,6 +132,9 @@ func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 
 	// Parse filer override if present in VolumeID
 	filerAddress, volumeId := DecodeVolumeID(req.VolumeId)
+	if clean := path.Clean(volumeId); clean == "." || clean == "/" || clean == "/buckets" {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid volume ID %q", req.VolumeId)
+	}
 
 	clientDriver := cs.Driver
 	if filerAddress != "" {
@@ -203,6 +206,9 @@ func (cs *ControllerServer) ValidateVolumeCapabilities(ctx context.Context, req 
 
 	// Parse filer override if present in VolumeID
 	filerAddress, volumeId := DecodeVolumeID(req.VolumeId)
+	if clean := path.Clean(volumeId); clean == "." || clean == "/" || clean == "/buckets" {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid volume ID %q", req.VolumeId)
+	}
 
 	clientDriver := cs.Driver
 	if filerAddress != "" {

--- a/pkg/driver/controllerserver.go
+++ b/pkg/driver/controllerserver.go
@@ -101,10 +101,7 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 
 	glog.V(4).Infof("volume created %s at %s", requestedVolumeId, volumePath)
 
-	volumeId := volumePath
-	if filerAddress != "" {
-		volumeId = fmt.Sprintf("%s@%s", filerAddress, volumePath)
-	}
+	volumeId := EncodeVolumeID(filerAddress, volumePath)
 
 	// Use full paths as VolumeID
 	// This keeps everything stateless
@@ -134,11 +131,7 @@ func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 	glog.V(4).Infof("deleting volume %s", volumeId)
 
 	// Parse filer override if present in VolumeID
-	filerAddress := ""
-	if idx := strings.Index(volumeId, "@"); idx != -1 {
-		filerAddress = volumeId[:idx]
-		volumeId = volumeId[idx+1:]
-	}
+	filerAddress, volumeId := DecodeVolumeID(req.VolumeId)
 
 	clientDriver := cs.Driver
 	if filerAddress != "" {
@@ -209,11 +202,7 @@ func (cs *ControllerServer) ValidateVolumeCapabilities(ctx context.Context, req 
 	}
 
 	// Parse filer override if present in VolumeID
-	filerAddress := ""
-	if idx := strings.Index(volumeId, "@"); idx != -1 {
-		filerAddress = volumeId[:idx]
-		volumeId = volumeId[idx+1:]
-	}
+	filerAddress, volumeId := DecodeVolumeID(req.VolumeId)
 
 	clientDriver := cs.Driver
 	if filerAddress != "" {

--- a/pkg/driver/controllerserver.go
+++ b/pkg/driver/controllerserver.go
@@ -88,17 +88,29 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		params[volumeCapacityKey] = strconv.FormatInt(capacity, 10)
 	}
 
-	if err := filer_pb.Mkdir(ctx, cs.Driver, parentDir, volumeName, nil); err != nil {
+	// Parse the filer parameter from the StorageClass parameters
+	filerAddress := params["filer"]
+	clientDriver := cs.Driver
+	if filerAddress != "" {
+		clientDriver = cs.Driver.CloneWithFiler(filerAddress)
+	}
+
+	if err := filer_pb.Mkdir(ctx, clientDriver, parentDir, volumeName, nil); err != nil {
 		return nil, fmt.Errorf("error creating volume: %v", err)
 	}
 
 	glog.V(4).Infof("volume created %s at %s", requestedVolumeId, volumePath)
 
+	volumeId := volumePath
+	if filerAddress != "" {
+		volumeId = fmt.Sprintf("%s@%s", filerAddress, volumePath)
+	}
+
 	// Use full paths as VolumeID
 	// This keeps everything stateless
 	return &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
-			VolumeId:      volumePath,
+			VolumeId:      volumeId,
 			CapacityBytes: capacity,
 			VolumeContext: params,
 		},
@@ -121,6 +133,18 @@ func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 	}
 	glog.V(4).Infof("deleting volume %s", volumeId)
 
+	// Parse filer override if present in VolumeID
+	filerAddress := ""
+	if idx := strings.Index(volumeId, "@"); idx != -1 {
+		filerAddress = volumeId[:idx]
+		volumeId = volumeId[idx+1:]
+	}
+
+	clientDriver := cs.Driver
+	if filerAddress != "" {
+		clientDriver = cs.Driver.CloneWithFiler(filerAddress)
+	}
+
 	var parentDir, volumeName string
 	if path.IsAbs(volumeId) {
 		parentDir = path.Dir(volumeId)
@@ -131,8 +155,8 @@ func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 		volumeName = volumeId
 	}
 
-	if err := filer_pb.Remove(ctx, cs.Driver, parentDir, volumeName, true, true, true, false, nil); err != nil {
-		return nil, fmt.Errorf("error deleting volume %s: %v", volumeId, err)
+	if err := filer_pb.Remove(ctx, clientDriver, parentDir, volumeName, true, true, true, false, nil); err != nil {
+		return nil, fmt.Errorf("error deleting volume %s: %v", req.VolumeId, err)
 	}
 
 	return &csi.DeleteVolumeResponse{}, nil
@@ -184,6 +208,18 @@ func (cs *ControllerServer) ValidateVolumeCapabilities(ctx context.Context, req 
 		return nil, status.Error(codes.InvalidArgument, "Volume capabilities missing in request")
 	}
 
+	// Parse filer override if present in VolumeID
+	filerAddress := ""
+	if idx := strings.Index(volumeId, "@"); idx != -1 {
+		filerAddress = volumeId[:idx]
+		volumeId = volumeId[idx+1:]
+	}
+
+	clientDriver := cs.Driver
+	if filerAddress != "" {
+		clientDriver = cs.Driver.CloneWithFiler(filerAddress)
+	}
+
 	var parentDir, volumeName string
 	if path.IsAbs(volumeId) {
 		parentDir = path.Dir(volumeId)
@@ -194,13 +230,13 @@ func (cs *ControllerServer) ValidateVolumeCapabilities(ctx context.Context, req 
 		volumeName = volumeId
 	}
 
-	exists, err := filer_pb.Exists(ctx, cs.Driver, parentDir, volumeName, true)
+	exists, err := filer_pb.Exists(ctx, clientDriver, parentDir, volumeName, true)
 	if err != nil {
-		return nil, fmt.Errorf("error checking bucket %s exists: %v", volumeId, err)
+		return nil, fmt.Errorf("error checking bucket %s exists: %v", req.VolumeId, err)
 	}
 	if !exists {
 		// return an error if the volume requested does not exist
-		return nil, status.Error(codes.NotFound, fmt.Sprintf("Volume with id %s does not exist", volumeId))
+		return nil, status.Error(codes.NotFound, fmt.Sprintf("Volume with id %s does not exist", req.VolumeId))
 	}
 
 	// We currently only support RWO

--- a/pkg/driver/controllerserver_test.go
+++ b/pkg/driver/controllerserver_test.go
@@ -55,3 +55,21 @@ func TestDeleteVolumeWithFilerOverride(t *testing.T) {
 		t.Fatalf("expected error to contain overridden filer address 'custom-filer', got: %v", err)
 	}
 }
+
+func TestDeleteVolumeWithInvalidVolumeId(t *testing.T) {
+	driver := NewSeaweedFsDriver("seaweedfs-csi", "global-filer:8888", "node-1", "unix://csi.sock", "", false)
+	cs := NewControllerServer(driver)
+
+	for _, invalidID := range []string{"filer://custom-filer:9999/", "filer://custom-filer:9999/buckets", "/", "/buckets"} {
+		req := &csi.DeleteVolumeRequest{
+			VolumeId: invalidID,
+		}
+		_, err := cs.DeleteVolume(context.Background(), req)
+		if err == nil {
+			t.Fatalf("expected error for invalid VolumeId %q, got nil", invalidID)
+		}
+		if !strings.Contains(err.Error(), "invalid volume ID") {
+			t.Fatalf("expected error message to contain 'invalid volume ID', got: %v", err)
+		}
+	}
+}

--- a/pkg/driver/controllerserver_test.go
+++ b/pkg/driver/controllerserver_test.go
@@ -1,0 +1,57 @@
+package driver
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+)
+
+func TestCreateVolumeWithFilerOverride(t *testing.T) {
+	driver := NewSeaweedFsDriver("seaweedfs-csi", "global-filer:8888", "node-1", "unix://csi.sock", "", false)
+	cs := NewControllerServer(driver)
+
+	req := &csi.CreateVolumeRequest{
+		Name: "test-volume",
+		Parameters: map[string]string{
+			"filer": "custom-filer:9999",
+		},
+		VolumeCapabilities: []*csi.VolumeCapability{
+			{
+				AccessMode: &csi.VolumeCapability_AccessMode{
+					Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+				},
+			},
+		},
+	}
+
+	_, err := cs.CreateVolume(context.Background(), req)
+	if err == nil {
+		t.Fatalf("expected error from connecting to nonexistent filer, got nil")
+	}
+
+	// The error should mention the overridden filer address
+	if !strings.Contains(err.Error(), "custom-filer") {
+		t.Fatalf("expected error to contain overridden filer address 'custom-filer', got: %v", err)
+	}
+}
+
+func TestDeleteVolumeWithFilerOverride(t *testing.T) {
+	driver := NewSeaweedFsDriver("seaweedfs-csi", "global-filer:8888", "node-1", "unix://csi.sock", "", false)
+	cs := NewControllerServer(driver)
+
+	req := &csi.DeleteVolumeRequest{
+		VolumeId: "custom-filer:9999@/buckets/test-volume",
+	}
+
+	_, err := cs.DeleteVolume(context.Background(), req)
+	if err == nil {
+		t.Fatalf("expected error from connecting to nonexistent filer, got nil")
+	}
+
+	// The error should mention the overridden filer address from VolumeId
+	if !strings.Contains(err.Error(), "custom-filer") {
+		t.Fatalf("expected error to contain overridden filer address 'custom-filer', got: %v", err)
+	}
+}

--- a/pkg/driver/controllerserver_test.go
+++ b/pkg/driver/controllerserver_test.go
@@ -42,7 +42,7 @@ func TestDeleteVolumeWithFilerOverride(t *testing.T) {
 	cs := NewControllerServer(driver)
 
 	req := &csi.DeleteVolumeRequest{
-		VolumeId: "custom-filer:9999@/buckets/test-volume",
+		VolumeId: "filer://custom-filer:9999/buckets/test-volume",
 	}
 
 	_, err := cs.DeleteVolume(context.Background(), req)

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -208,3 +208,9 @@ func (d *SeaweedFsDriver) AdjustedUrl(location *filer_pb.Location) string {
 func (d *SeaweedFsDriver) GetDataCenter() string {
 	return d.DataCenter
 }
+
+func (d *SeaweedFsDriver) CloneWithFiler(filer string) *SeaweedFsDriver {
+	clone := *d
+	clone.filers = pb.ServerAddresses(filer).ToAddresses()
+	return &clone
+}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -212,5 +212,6 @@ func (d *SeaweedFsDriver) GetDataCenter() string {
 func (d *SeaweedFsDriver) CloneWithFiler(filer string) *SeaweedFsDriver {
 	clone := *d
 	clone.filers = pb.ServerAddresses(filer).ToAddresses()
+	clone.filerIndex = 0
 	return &clone
 }

--- a/pkg/driver/mounter.go
+++ b/pkg/driver/mounter.go
@@ -62,13 +62,11 @@ func (m *mountServiceMounter) Mount(target string) (Unmounter, error) {
 		filers[i] = string(address)
 	}
 
-	// Parse filer override from volumeID first
+	// Prefer the stateless filer encoded in VolumeID. Fall back to volume
+	// context only for legacy/static volumes that do not encode a filer.
 	if filerAddr, _ := DecodeVolumeID(m.volumeID); filerAddr != "" {
 		filers = []string{filerAddr}
-	}
-
-	// Then allow volume context to override it if set
-	if customFiler, ok := m.volContext["filer"]; ok && customFiler != "" {
+	} else if customFiler, ok := m.volContext["filer"]; ok && customFiler != "" {
 		filers = []string{customFiler}
 	}
 

--- a/pkg/driver/mounter.go
+++ b/pkg/driver/mounter.go
@@ -63,8 +63,8 @@ func (m *mountServiceMounter) Mount(target string) (Unmounter, error) {
 	}
 
 	// Parse filer override from volumeID first
-	if idx := strings.Index(m.volumeID, "@"); idx != -1 {
-		filers = []string{m.volumeID[:idx]}
+	if filerAddr, _ := DecodeVolumeID(m.volumeID); filerAddr != "" {
+		filers = []string{filerAddr}
 	}
 
 	// Then allow volume context to override it if set
@@ -111,10 +111,7 @@ func (m *mountServiceMounter) buildMountArgs(targetPath, cacheDir, localSocket s
 	}
 
 	var filerPath string
-	cleanVolumeID := m.volumeID
-	if idx := strings.Index(cleanVolumeID, "@"); idx != -1 {
-		cleanVolumeID = cleanVolumeID[idx+1:]
-	}
+	_, cleanVolumeID := DecodeVolumeID(m.volumeID)
 
 	if path.IsAbs(cleanVolumeID) {
 		// path already resolved in controller and passed as volumeID

--- a/pkg/driver/mounter.go
+++ b/pkg/driver/mounter.go
@@ -62,6 +62,16 @@ func (m *mountServiceMounter) Mount(target string) (Unmounter, error) {
 		filers[i] = string(address)
 	}
 
+	// Parse filer override from volumeID first
+	if idx := strings.Index(m.volumeID, "@"); idx != -1 {
+		filers = []string{m.volumeID[:idx]}
+	}
+
+	// Then allow volume context to override it if set
+	if customFiler, ok := m.volContext["filer"]; ok && customFiler != "" {
+		filers = []string{customFiler}
+	}
+
 	cacheDir := GetCacheDir(m.driver.CacheDir, m.volumeID)
 	localSocket := GetLocalSocket(m.driver.volumeSocketDir, m.volumeID)
 
@@ -101,9 +111,14 @@ func (m *mountServiceMounter) buildMountArgs(targetPath, cacheDir, localSocket s
 	}
 
 	var filerPath string
-	if path.IsAbs(m.volumeID) {
+	cleanVolumeID := m.volumeID
+	if idx := strings.Index(cleanVolumeID, "@"); idx != -1 {
+		cleanVolumeID = cleanVolumeID[idx+1:]
+	}
+
+	if path.IsAbs(cleanVolumeID) {
 		// path already resolved in controller and passed as volumeID
-		filerPath = m.volumeID
+		filerPath = cleanVolumeID
 	} else {
 		// non-absolute-path volume ID, volume is either legacy or this is a static provision
 		contextPath := volumeContext["path"]

--- a/pkg/driver/mounter_test.go
+++ b/pkg/driver/mounter_test.go
@@ -2,6 +2,7 @@ package driver
 
 import (
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -37,5 +38,38 @@ func TestInitialCollectionQuotaMBRoundsUp(t *testing.T) {
 func TestInitialCollectionQuotaMBDisablesOneByteSentinel(t *testing.T) {
 	if got := initialCollectionQuotaMB("1"); got != "" {
 		t.Fatalf("initialCollectionQuotaMB = %q, want empty", got)
+	}
+}
+
+func TestBuildMountArgsWithFilerOverride(t *testing.T) {
+	mounter := &mountServiceMounter{
+		driver:   &SeaweedFsDriver{},
+		volumeID: "custom-filer:8888@/buckets/pvc-1234",
+		volContext: map[string]string{
+			"filer": "override-filer:8888",
+		},
+	}
+
+	// 1. Verify volumeID parsing
+	cleanVolumeID := mounter.volumeID
+	if idx := strings.Index(cleanVolumeID, "@"); idx != -1 {
+		cleanVolumeID = cleanVolumeID[idx+1:]
+	}
+	if cleanVolumeID != "/buckets/pvc-1234" {
+		t.Fatalf("expected clean volume ID to be /buckets/pvc-1234, got %q", cleanVolumeID)
+	}
+
+	// 2. Verify mount args generation
+	args, err := mounter.buildMountArgs(
+		"/staging",
+		"/cache",
+		"/socket",
+		[]string{"override-filer:8888"},
+	)
+	if err != nil {
+		t.Fatalf("buildMountArgs: %v", err)
+	}
+	if !slices.Contains(args, "-filer=override-filer:8888") {
+		t.Fatalf("mount args do not contain overridden filer: %v", args)
 	}
 }

--- a/pkg/driver/mounter_test.go
+++ b/pkg/driver/mounter_test.go
@@ -2,7 +2,6 @@ package driver
 
 import (
 	"slices"
-	"strings"
 	"testing"
 )
 
@@ -44,17 +43,14 @@ func TestInitialCollectionQuotaMBDisablesOneByteSentinel(t *testing.T) {
 func TestBuildMountArgsWithFilerOverride(t *testing.T) {
 	mounter := &mountServiceMounter{
 		driver:   &SeaweedFsDriver{},
-		volumeID: "custom-filer:8888@/buckets/pvc-1234",
+		volumeID: "filer://custom-filer:8888/buckets/pvc-1234",
 		volContext: map[string]string{
 			"filer": "override-filer:8888",
 		},
 	}
 
 	// 1. Verify volumeID parsing
-	cleanVolumeID := mounter.volumeID
-	if idx := strings.Index(cleanVolumeID, "@"); idx != -1 {
-		cleanVolumeID = cleanVolumeID[idx+1:]
-	}
+	_, cleanVolumeID := DecodeVolumeID(mounter.volumeID)
 	if cleanVolumeID != "/buckets/pvc-1234" {
 		t.Fatalf("expected clean volume ID to be /buckets/pvc-1234, got %q", cleanVolumeID)
 	}

--- a/pkg/driver/utils.go
+++ b/pkg/driver/utils.go
@@ -190,3 +190,34 @@ func CheckDataLocality(dataLocality *datalocality.DataLocality, dataCenter *stri
 	}
 	return nil
 }
+
+const FilerVolumeIDPrefix = "filer://"
+
+// EncodeVolumeID constructs a structured volume ID from filerAddress and volumePath.
+// If filerAddress is empty, it returns the volumePath directly.
+// Otherwise, it formats it as "filer://<filerAddress><volumePath>".
+func EncodeVolumeID(filerAddress, volumePath string) string {
+	if filerAddress == "" {
+		return volumePath
+	}
+	filerAddress = strings.TrimSuffix(filerAddress, "/")
+	if !strings.HasPrefix(volumePath, "/") {
+		volumePath = "/" + volumePath
+	}
+	return FilerVolumeIDPrefix + filerAddress + volumePath
+}
+
+// DecodeVolumeID parses a structured volume ID into filerAddress and volumePath.
+// If the volumeId starts with "filer://", it parses the filerAddress and volumePath dynamically.
+// Otherwise, it returns an empty filerAddress and the original volumeId as the volumePath.
+func DecodeVolumeID(volumeID string) (string, string) {
+	if strings.HasPrefix(volumeID, FilerVolumeIDPrefix) {
+		trimmed := strings.TrimPrefix(volumeID, FilerVolumeIDPrefix)
+		idx := strings.Index(trimmed, "/")
+		if idx != -1 {
+			return trimmed[:idx], trimmed[idx:]
+		}
+		return trimmed, "/"
+	}
+	return "", volumeID
+}

--- a/pkg/driver/utils.go
+++ b/pkg/driver/utils.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -191,33 +192,28 @@ func CheckDataLocality(dataLocality *datalocality.DataLocality, dataCenter *stri
 	return nil
 }
 
-const FilerVolumeIDPrefix = "filer://"
-
 // EncodeVolumeID constructs a structured volume ID from filerAddress and volumePath.
 // If filerAddress is empty, it returns the volumePath directly.
-// Otherwise, it formats it as "filer://<filerAddress><volumePath>".
+// Otherwise, it formats it as a "filer://<filerAddress><volumePath>" URI.
 func EncodeVolumeID(filerAddress, volumePath string) string {
 	if filerAddress == "" {
 		return volumePath
 	}
-	filerAddress = strings.TrimSuffix(filerAddress, "/")
-	if !strings.HasPrefix(volumePath, "/") {
-		volumePath = "/" + volumePath
+	u := &url.URL{
+		Scheme: "filer",
+		Host:   filerAddress,
+		Path:   volumePath,
 	}
-	return FilerVolumeIDPrefix + filerAddress + volumePath
+	return u.String()
 }
 
 // DecodeVolumeID parses a structured volume ID into filerAddress and volumePath.
-// If the volumeId starts with "filer://", it parses the filerAddress and volumePath dynamically.
+// If the volumeId is a valid "filer://" URI, it parses the host and path.
 // Otherwise, it returns an empty filerAddress and the original volumeId as the volumePath.
 func DecodeVolumeID(volumeID string) (string, string) {
-	if strings.HasPrefix(volumeID, FilerVolumeIDPrefix) {
-		trimmed := strings.TrimPrefix(volumeID, FilerVolumeIDPrefix)
-		idx := strings.Index(trimmed, "/")
-		if idx != -1 {
-			return trimmed[:idx], trimmed[idx:]
-		}
-		return trimmed, "/"
+	u, err := url.Parse(volumeID)
+	if err != nil || u.Scheme != "filer" {
+		return "", volumeID
 	}
-	return "", volumeID
+	return u.Host, u.Path
 }


### PR DESCRIPTION
Allows routing volume creations and FUSE mounts dynamically to different SeaweedFS filers by specifying the 'filer' parameter in the StorageClass. Utilizes a clean 'filer://' structured URI format for stateless VolumeId routing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a filer address in provisioning and mount flows.
  * Volume IDs can now carry filer information, allowing storage operations to target a specific filer.
* **Bug Fixes**
  * Improved handling of existing volumes and capability checks when a filer override is present.
  * Mount behavior now honors filer settings from both the volume ID and storage class parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->