### PR TITLE
feat: supports setting nodeSelector

### DIFF
--- a/deploy/helm/seaweedfs-csi-driver/templates/daemonset-mount.yaml
+++ b/deploy/helm/seaweedfs-csi-driver/templates/daemonset-mount.yaml
@@ -23,6 +23,9 @@ spec:
     spec:
       priorityClassName: {{ $priorityClass }}
       serviceAccountName: {{ $mountSA }}
+      {{- with .Values.mountService.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.mountService.affinity }}
       affinity: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/deploy/helm/seaweedfs-csi-driver/templates/daemonset.yaml
+++ b/deploy/helm/seaweedfs-csi-driver/templates/daemonset.yaml
@@ -33,6 +33,9 @@ spec:
       {{- end }}
       #hostNetwork: true
       #dnsPolicy: ClusterFirstWithHostNet
+      {{- with .Values.node.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.node.affinity }}
       affinity: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/deploy/helm/seaweedfs-csi-driver/templates/deployment.yaml
+++ b/deploy/helm/seaweedfs-csi-driver/templates/deployment.yaml
@@ -15,6 +15,9 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: {{ template "seaweedfs-csi-driver.name" . }}-controller-sa
+      {{- with .Values.controller.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
+      {{- end }}
       affinity:
         {{- if and .Values.controller.affinity .Values.controller.affinity.nodeAffinity }}
         nodeAffinity: {{ toYaml .Values.controller.affinity.nodeAffinity | nindent 10 }}

--- a/deploy/helm/seaweedfs-csi-driver/values.yaml
+++ b/deploy/helm/seaweedfs-csi-driver/values.yaml
@@ -125,6 +125,7 @@ mountService:
   # This allows manual, controlled updates to prevent automated disruption of active mounts.
   updateStrategy:
     type: OnDelete
+  nodeSelector: {}
   affinity: {}
   tolerations:
   resources: {}
@@ -135,6 +136,7 @@ driverName: seaweedfs-csi-driver
 
 controller:
   replicas: 1
+  nodeSelector: {}
   affinity: {}
   tolerations:
   resources: {}
@@ -170,6 +172,7 @@ node:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 25%
+  nodeSelector: {}
   affinity: {}
   tolerations:
   livenessProbe:


### PR DESCRIPTION
## Summary

This PR adds nodeSelector support to the Helm chart workloads:

* daemonset.yaml
  Adds `node.nodeSelector` for the CSI Node DaemonSet
* daemonset-mount.yaml
  Adds `mountService.nodeSelector` for the Mount Service DaemonSet
* deployment.yaml
  Adds `controller.nodeSelector` for the Controller Deployment
* values.yaml
  Adds default values for the new configuration options
  
## Motivation

This allows users to schedule SeaweedFS CSI components onto specific Kubernetes nodes.
For example, components can be scheduled only on worker nodes and excluded from master/control-plane nodes by using node labels.

## Compatibility

This change is backward compatible:

* Default nodeSelector values are empty
* Existing deployments are not affected unless users configure nodeSelector
* Scheduling behavior remains unchanged by default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable `nodeSelector` support for the CSI driver’s controller, node, and mount service components.
  * Helm templates now render `nodeSelector` in the controller/node/mount Pod specs when the corresponding values are provided.
  * Updated default chart values to include empty `nodeSelector` entries for each component (non-restrictive by default).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->