### PR TITLE
fix(helm): share one nodeSelector between node plugin and mount service

### DIFF
--- a/deploy/helm/seaweedfs-csi-driver/templates/daemonset-mount.yaml
+++ b/deploy/helm/seaweedfs-csi-driver/templates/daemonset-mount.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       priorityClassName: {{ $priorityClass }}
       serviceAccountName: {{ $mountSA }}
-      {{- with .Values.mountService.nodeSelector }}
+      {{- with .Values.node.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.mountService.affinity }}

--- a/deploy/helm/seaweedfs-csi-driver/values.yaml
+++ b/deploy/helm/seaweedfs-csi-driver/values.yaml
@@ -125,7 +125,6 @@ mountService:
   # This allows manual, controlled updates to prevent automated disruption of active mounts.
   updateStrategy:
     type: OnDelete
-  nodeSelector: {}
   affinity: {}
   tolerations:
   resources: {}


### PR DESCRIPTION
Follow-up to #290, which added `nodeSelector` to the three chart workloads.

## The problem

`node.nodeSelector` and `mountService.nodeSelector` are independent values, but the two DaemonSets are coupled per-node. The node plugin reaches the mount service over a unix socket shared through a hostPath:

- `templates/daemonset.yaml` mounts `$mountHostPath` with `type: DirectoryOrCreate`
- `templates/daemonset-mount.yaml` mounts the same path

`DirectoryOrCreate` is what makes this bite. Point the two selectors at different labels — or set one and forget the other — and the node plugin schedules onto nodes with no mount service pod. Kubernetes obligingly creates the empty socket directory, the pod passes its probes, and nothing looks wrong. The failure surfaces later as a hung mount on the first volume that lands there.

## The change

Render both DaemonSets from `node.nodeSelector` and drop `mountService.nodeSelector`.

The two DaemonSets are split for **lifecycle** reasons, not scheduling ones — the mount service uses `OnDelete` so updates don't disrupt active mounts, while the node plugin rolls normally. For placement they are one unit, and equality is the only configuration that makes sense:

- mount service **narrower** than the node plugin → hung mounts, as above
- mount service **broader** → pure waste; nothing else consumes that socket

So this makes the broken state unrepresentable rather than merely detectable. An earlier revision of this PR validated the two selectors against each other with a `fail` and an opt-out flag; sharing one value removes ~40 lines of guard, error message, and escape hatch in favour of a one-line template change.

`controller.nodeSelector` is deliberately untouched — the controller mounts only an unrelated `pluginproxy` socket dir and has no hostPath dependency on the mount service, so it is a genuinely independent knob.

## Compatibility

`mountService.nodeSelector` merged on 2026-07-28, after the v1.4.26 release (2026-07-20), and `helm_release.yaml` publishes charts only on `release: published`. **It has never shipped**, so no migration is needed.

Anyone who picked it up from master gets it silently ignored, which errs safe: the mount service becomes eligible for every node rather than a subset, so the worst case is surplus pods, never a split pair.

## Verification

- `node.nodeSelector` reaches exactly the two DaemonSets (`t-node`, `t-mount`) and nothing else
- `controller.nodeSelector` still renders independently
- manifests at default values are **byte-identical** to master (`diff` clean)
- `helm lint` passes