### PR TITLE
fix: don't ReadDir the mount root in the health-check liveness probe

### DIFF
--- a/pkg/driver/mount_util.go
+++ b/pkg/driver/mount_util.go
@@ -53,13 +53,21 @@ func isStagingPathHealthy(stagingPath string) bool {
 		return false
 	}
 
-	// Try to read the directory to verify FUSE is responsive
-	_, err = os.ReadDir(stagingPath)
-	if err != nil {
-		glog.Warningf("staging path %s is not readable (FUSE may be dead): %v", stagingPath, err)
-		return false
-	}
-
+	// Deliberately not calling os.ReadDir(stagingPath) here. It used to be a
+	// "FUSE is responsive" probe, but ReadDir enumerates the *entire* root
+	// directory, and seaweedfs mount answers a readdir by fetching the whole
+	// listing from the filer before returning anything to the kernel — on a
+	// bucket with a large root this can legitimately take many minutes even
+	// though the mount is perfectly healthy. checkHealth's 5s timeout then
+	// marks it unhealthy and triggers a remount, which restarts that same
+	// slow listing from scratch: the mount can never finish enumerating and
+	// gets stuck in a permanent recovery loop.
+	//
+	// The os.Stat + IsMountPoint checks above already exercise a FUSE GETATTR
+	// round-trip on the root inode (cost independent of directory size) and
+	// already catch a dead/disconnected daemon via IsCorruptedMnt (ENOTCONN),
+	// which was the actual failure mode behind issue #261. That's sufficient
+	// liveness evidence without paying for a full directory scan.
 	glog.V(4).Infof("staging path %s is healthy", stagingPath)
 	return true
 }

--- a/pkg/driver/mount_util_test.go
+++ b/pkg/driver/mount_util_test.go
@@ -31,7 +31,12 @@ func TestIsStagingPathHealthy_DoesNotRequireListableDirectory(t *testing.T) {
 	if err := os.Chmod(stagingPath, 0o000); err != nil {
 		t.Fatalf("chmod: %v", err)
 	}
-	defer os.Chmod(stagingPath, 0o755) // t.TempDir cleanup needs it readable again
+	defer func() {
+		// t.TempDir cleanup needs it readable again
+		if err := os.Chmod(stagingPath, 0o755); err != nil {
+			t.Errorf("chmod cleanup: %v", err)
+		}
+	}()
 
 	if _, err := os.ReadDir(stagingPath); err == nil {
 		t.Fatalf("test setup invalid: ReadDir on a 0-permission dir should fail")

--- a/pkg/driver/mount_util_test.go
+++ b/pkg/driver/mount_util_test.go
@@ -1,0 +1,65 @@
+package driver
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/mount-utils"
+)
+
+// isStagingPathHealthy must not require the mount root to be listable.
+// seaweedfs mount answers a readdir of the root by fetching the *entire*
+// directory listing from the filer before returning anything to the
+// kernel; on a bucket with a large root that can take many minutes even
+// though the mount is perfectly healthy. Simulating "unlistable" with a
+// 0-permission directory: os.Stat still succeeds (stat only needs search
+// permission on the parent), but os.ReadDir would fail with EACCES. If
+// isStagingPathHealthy regresses to calling ReadDir again, this test
+// catches it (as root, os.ReadDir ignores permission bits, so this test
+// must not be run as root).
+func TestIsStagingPathHealthy_DoesNotRequireListableDirectory(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission bits are not enforced for root")
+	}
+
+	dir := t.TempDir()
+	stagingPath := filepath.Join(dir, "staging")
+	if err := os.Mkdir(stagingPath, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Chmod(stagingPath, 0o000); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	defer os.Chmod(stagingPath, 0o755) // t.TempDir cleanup needs it readable again
+
+	if _, err := os.ReadDir(stagingPath); err == nil {
+		t.Fatalf("test setup invalid: ReadDir on a 0-permission dir should fail")
+	}
+
+	origMountutil := mountutil
+	mountutil = mount.NewFakeMounter([]mount.MountPoint{{Path: stagingPath}})
+	defer func() { mountutil = origMountutil }()
+
+	if !isStagingPathHealthy(stagingPath) {
+		t.Fatal("expected staging path to be healthy: liveness must not depend on the root directory being listable")
+	}
+}
+
+func TestIsStagingPathHealthy_MissingPath(t *testing.T) {
+	if isStagingPathHealthy(filepath.Join(t.TempDir(), "does-not-exist")) {
+		t.Fatal("expected missing staging path to be unhealthy")
+	}
+}
+
+func TestIsStagingPathHealthy_NotAMountPoint(t *testing.T) {
+	dir := t.TempDir()
+
+	origMountutil := mountutil
+	mountutil = mount.NewFakeMounter(nil) // no mount points registered
+	defer func() { mountutil = origMountutil }()
+
+	if isStagingPathHealthy(dir) {
+		t.Fatal("expected a plain directory that isn't a mount point to be unhealthy")
+	}
+}


### PR DESCRIPTION
## Problem

`isStagingPathHealthy`'s last check reads the entire root directory
(`os.ReadDir(stagingPath)`) to prove FUSE is responsive. `weed mount`
answers a readdir of the root by fetching the whole listing from the
filer before returning anything to the kernel, so on a bucket with a
large/deep root this can legitimately take many minutes even though
the mount is perfectly healthy.

`checkHealth`'s 5s timeout then marks the volume unhealthy, and the
health monitor unmounts + remounts it — which restarts that same slow
listing from scratch. The mount can never finish enumerating and gets
stuck in a permanent recovery loop.

Reproduced with a static PV pointing at an external filer serving a
~2.6TB bucket: `ls` on the mount root never completes because the
mount gets torn down every ~30s by the health monitor. A direct file
open by path (no readdir) works fine. On the same backend, mounting
with plain `weed mount` (no CSI/health-monitor loop) succeeds — the
initial listing just takes a while (~17min in that environment) and is
fast afterwards.

## Fix

Drop the `ReadDir` call. The `os.Stat` + `IsMountPoint` checks earlier
in the same function already exercise a FUSE GETATTR round-trip on the
root inode (cost independent of directory size) and already catch a
dead/disconnected daemon via `IsCorruptedMnt` (ENOTCONN) — the actual
failure mode behind #261. That's sufficient liveness evidence without
paying for a full directory scan.

## Test plan

- [x] `go build ./...`, `go vet ./...`
- [x] Added `pkg/driver/mount_util_test.go`: the main case creates a
      staging dir with `chmod 000` (so `ReadDir` would fail with
      EACCES while `Stat` still succeeds) behind a `mount.FakeMounter`,
      and asserts `isStagingPathHealthy` still reports healthy —
      regresses if `ReadDir` is reintroduced.
- [x] `go test ./pkg/driver/...` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved staging path health checks to avoid delays caused by scanning entire directories.
  * Continued detecting missing, corrupted, and unmounted staging paths reliably.

* **Tests**
  * Added coverage for unlistable directories, missing paths, and directories that are not mount points.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->