### PR TITLE
Expose storageClass parameters through helm chart values

### DIFF
--- a/deploy/helm/seaweedfs-csi-driver/templates/storageclass.yaml
+++ b/deploy/helm/seaweedfs-csi-driver/templates/storageclass.yaml
@@ -11,6 +11,9 @@ provisioner: {{ .Values.driverName }}
 allowVolumeExpansion: true
 volumeBindingMode: {{ .Values.storageClassVolumeBindingMode | default "Immediate" }}
 {{- with .Values.storageClassParameters }}
-parameters: {{ . | toYaml | nindent 2 }}
+parameters:
+  {{- range $key, $value := . }}
+  {{ $key }}: {{ $value | toString | quote }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/deploy/helm/seaweedfs-csi-driver/templates/storageclass.yaml
+++ b/deploy/helm/seaweedfs-csi-driver/templates/storageclass.yaml
@@ -10,4 +10,7 @@ metadata:
 provisioner: {{ .Values.driverName }}
 allowVolumeExpansion: true
 volumeBindingMode: {{ .Values.storageClassVolumeBindingMode | default "Immediate" }}
+{{- with .Values.storageClassParameters }}
+parameters: {{ . | toYaml | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/deploy/helm/seaweedfs-csi-driver/values.yaml
+++ b/deploy/helm/seaweedfs-csi-driver/values.yaml
@@ -2,6 +2,10 @@
 seaweedfsFiler: "SEAWEEDFS_FILER:8888"
 storageClassName: seaweedfs-storage
 storageClassVolumeBindingMode: Immediate
+# parameters for the storage class created by the chart. Example:
+# storageClassParameters:
+#   volumeServerAccess: "filerProxy"
+storageClassParameters: {}
 isDefaultStorageClass: false
 tlsSecret: ""
 #logVerbosity: 4


### PR DESCRIPTION
This exposes the `parameters` of the `storageClass` created by the helm chart, so they can be set them in the helm values.

It allows, for example, to [mount over the internet](https://github.com/seaweedfs/seaweedfs/wiki/Mount-over-the-Internet) with only the filer exposed:

```yaml
helm install \
  --set seaweedfsFiler=<filerHost:port> \
  --set storageClassParameters.volumeServerAccess=filerProxy \
  seaweedfs-csi-driver ./deploy/helm/seaweedfs-csi-driver
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable StorageClass parameters to the Helm chart.
  * StorageClass parameters can now be defined through the chart’s values configuration.
  * Configured parameters are automatically included in the generated StorageClass resource.
  * Existing deployments remain unchanged when no additional parameters are specified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->