### PR TITLE
go 1.26

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26'
 
       - name: Vet
         run: go vet ./...
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26'
 
       - name: Build CSI driver
         run: |

--- a/.github/workflows/sync-seaweedfs.yaml
+++ b/.github/workflows/sync-seaweedfs.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.26'
 
       - name: Get current SeaweedFS version
         id: current_version

--- a/cmd/seaweedfs-csi-driver/Dockerfile
+++ b/cmd/seaweedfs-csi-driver/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine as builder
+FROM golang:1.26-alpine as builder
 
 RUN apk add git g++
 

--- a/cmd/seaweedfs-csi-driver/Dockerfile.dev
+++ b/cmd/seaweedfs-csi-driver/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine as builder
+FROM golang:1.26-alpine as builder
 
 RUN apk add git g++
 

--- a/cmd/seaweedfs-mount/Dockerfile
+++ b/cmd/seaweedfs-mount/Dockerfile
@@ -2,7 +2,7 @@
 # Update via: docker build --build-arg SEAWEEDFS_COMMIT=<hash> ...
 ARG SEAWEEDFS_COMMIT=5c43c03b76c0
 
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 RUN apk add git g++
 

--- a/cmd/seaweedfs-mount/Dockerfile.dev
+++ b/cmd/seaweedfs-mount/Dockerfile.dev
@@ -2,7 +2,7 @@
 # Update via: docker build --build-arg SEAWEEDFS_COMMIT=<hash> ...
 ARG SEAWEEDFS_COMMIT=5c43c03b76c0
 
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 RUN apk add git g++
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/seaweedfs/seaweedfs-csi-driver
 
-go 1.25.8
+go 1.26.0
 
 require (
 	github.com/container-storage-interface/spec v1.11.0


### PR DESCRIPTION
SeaweedFS is moving its go.mod directive to 1.26 (the etcd client v3 3.7.1 bump,
seaweedfs/seaweedfs#10789, with the build-image sweep in seaweedfs/seaweedfs#10797).
Once that lands, anything building against seaweedfs needs a 1.26 toolchain, and
the official Go images set `GOTOOLCHAIN=local` so they cannot upgrade themselves:

    go: go.mod requires go >= 1.26 (running go 1.25.13; GOTOOLCHAIN=local)

The weekly `Sync SeaweedFS Dependency` job is the first thing that would break here:
it runs `go get -u github.com/seaweedfs/seaweedfs@latest && go mod tidy` on Go 1.24.

Bumps the four builder images, the sync and integration-test workflows, and our own
go.mod directive (`go get` would raise it to 1.26 on the next sync anyway).
`go build ./...` and `go vet ./...` are clean on go1.26.4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project and build environments to Go 1.26.
  * Updated development and production container builds to use Go 1.26.
  * Updated automated unit and integration test workflows to run with Go 1.26.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->