### PR TITLE
Report accessible topology in NodeGetInfo (fixes #300)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - [Testing](#testing)
 - [Static and dynamic provisioning](#static-and-dynamic-provisioning)
 - [DataLocality](#datalocality)
+- [Node topology](#node-topology)
 - [License](#license)
 - [Code of conduct](#code-of-conduct)
 
@@ -270,6 +271,31 @@ You can activate it in the Helm-Chart `values.yaml` -> `node.injectTopologyInfoF
 `node.injectTopologyInfoFromNodeLabel.labels` decides which labels are grabbed from the node.
 
 It is recommended to use [well-known labels](https://kubernetes.io/docs/reference/labels-annotations-taints/#topologykubernetesioregion) to avoid confusion.
+
+# Node topology
+
+When the driver only runs on some nodes, report the labels of those nodes as accessible topology. `CSINode.spec.drivers[].topologyKeys` then gets populated, provisioned PVs get a matching `nodeAffinity` and the scheduler stops placing pods with SeaweedFS PVCs on nodes without the driver.
+
+Level               | Location
+------------------- | --------
+Driver              | Helm: `values.yaml` -> `topologyKeys` <br> Or `DaemonSet` / `Deployment` -> Container `csi-seaweedfs-plugin` -> args `--topologyKeys=`
+
+```yaml
+topologyKeys:
+  - topology.kubernetes.io/zone
+```
+
+Every key is looked up in the labels of the node the driver runs on; keys the node does not have are skipped. A StorageClass can then restrict where volumes are provisioned:
+
+```yaml
+allowedTopologies:
+  - matchLabelExpressions:
+      - key: topology.kubernetes.io/zone
+        values:
+          - zone-a
+```
+
+The node ServiceAccount needs `get` on `nodes`, which the Helm chart already grants.
 
 # License
 [Apache v2 license](https://www.apache.org/licenses/LICENSE-2.0)

--- a/README.md
+++ b/README.md
@@ -278,14 +278,14 @@ When the driver only runs on some nodes, report the labels of those nodes as acc
 
 Level               | Location
 ------------------- | --------
-Driver              | Helm: `values.yaml` -> `topologyKeys` <br> Or `DaemonSet` / `Deployment` -> Container `csi-seaweedfs-plugin` -> args `--topologyKeys=`
+Driver              | Helm: `values.yaml` -> `topologyKeys` <br> Or args `--topologyKeys=` on Container `csi-seaweedfs-plugin` (`DaemonSet`) and Container `seaweedfs-csi-plugin` (`Deployment`)
 
 ```yaml
 topologyKeys:
   - topology.kubernetes.io/zone
 ```
 
-Every key is looked up in the labels of the node the driver runs on; keys the node does not have are skipped. A StorageClass can then restrict where volumes are provisioned:
+Every key is looked up in the labels of the node the driver runs on; keys the node does not have are skipped. The CSI spec asks for a single key prefix across all topology keys, so prefer keys such as `topology.kubernetes.io/zone` and `topology.kubernetes.io/region` together. A StorageClass can then restrict where volumes are provisioned:
 
 ```yaml
 allowedTopologies:

--- a/cmd/seaweedfs-csi-driver/main.go
+++ b/cmd/seaweedfs-csi-driver/main.go
@@ -31,6 +31,7 @@ var (
 	gidMap            = flag.String("map.gid", "", "map local gid to gid on filer, comma-separated <local_gid>:<filer_gid>")
 	dataCenter        = flag.String("dataCenter", "", "dataCenter this node is running in (locality-definition)")
 	dataLocalityStr   = flag.String("dataLocality", "", "which volume-nodes pods will use for activity (one-of: 'write_preferLocalDc'). Requires used locality-definitions to be set")
+	topologyKeys      = flag.String("topologyKeys", "", "comma-separated node label keys reported as accessible topology, e.g. topology.kubernetes.io/zone")
 	dataLocality      datalocality.DataLocality
 )
 
@@ -95,6 +96,7 @@ func main() {
 	drv.GidMap = *gidMap
 	drv.DataCenter = *dataCenter
 	drv.DataLocality = dataLocality
+	drv.TopologyKeys = driver.ParseTopologyKeys(*topologyKeys)
 
 	drv.Run()
 }

--- a/deploy/helm/seaweedfs-csi-driver/templates/daemonset.yaml
+++ b/deploy/helm/seaweedfs-csi-driver/templates/daemonset.yaml
@@ -63,6 +63,9 @@ spec:
             {{- if .Values.node.injectTopologyInfoFromNodeLabel.enabled }}
             - --dataCenter=$(DATACENTER)
             {{- end }}
+            {{- with .Values.topologyKeys }}
+            - --topologyKeys={{ join "," . }}
+            {{- end }}
             - --components=node
             {{- with .Values.concurrentWriters }}
             - --concurrentWriters={{ . }}

--- a/deploy/helm/seaweedfs-csi-driver/templates/deployment.yaml
+++ b/deploy/helm/seaweedfs-csi-driver/templates/deployment.yaml
@@ -53,6 +53,9 @@ spec:
             - --driverName=$(DRIVER_NAME)
             - --components=controller
             - --attacher={{ .Values.csiAttacher.enabled }}
+            {{- with .Values.topologyKeys }}
+            - --topologyKeys={{ join "," . }}
+            {{- end }}
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
@@ -95,6 +98,9 @@ spec:
             - --leader-election
             - --leader-election-namespace={{ .Release.Namespace }}
             - --http-endpoint=:9809
+            {{- if .Values.topologyKeys }}
+            - --feature-gates=Topology=true
+            {{- end }}
             #- --v=9
           env:
             - name: ADDRESS

--- a/deploy/helm/seaweedfs-csi-driver/values.yaml
+++ b/deploy/helm/seaweedfs-csi-driver/values.yaml
@@ -137,6 +137,12 @@ mountService:
 
 driverName: seaweedfs-csi-driver
 
+# Node label keys reported as the accessible topology of each node, e.g.
+# ["topology.kubernetes.io/zone"]. When set, CSINode gets topologyKeys, so
+# StorageClass allowedTopologies is honoured and pods with SeaweedFS PVCs are
+# only scheduled on nodes running this driver.
+topologyKeys: []
+
 controller:
   replicas: 1
   nodeSelector: {}

--- a/pkg/driver/controllerserver.go
+++ b/pkg/driver/controllerserver.go
@@ -98,9 +98,10 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	// This keeps everything stateless
 	return &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
-			VolumeId:      volumePath,
-			CapacityBytes: capacity,
-			VolumeContext: params,
+			VolumeId:           volumePath,
+			CapacityBytes:      capacity,
+			VolumeContext:      params,
+			AccessibleTopology: accessibleTopology(req.GetAccessibilityRequirements()),
 		},
 	}, nil
 }
@@ -249,6 +250,16 @@ func (cs *ControllerServer) ControllerExpandVolume(ctx context.Context, req *csi
 		CapacityBytes:         capacity,
 		NodeExpansionRequired: true,
 	}, nil
+}
+
+// accessibleTopology reports where a created volume can be used. The filer is
+// reachable from every node running the plugin, so the volume is accessible
+// from all requested segments instead of a single preferred one.
+func accessibleTopology(requirements *csi.TopologyRequirement) []*csi.Topology {
+	if topologies := requirements.GetRequisite(); len(topologies) > 0 {
+		return topologies
+	}
+	return requirements.GetPreferred()
 }
 
 func sanitizeVolumeIdS3(volumeId string) string {

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -50,6 +50,7 @@ type SeaweedFsDriver struct {
 	signature         int32
 	DataCenter        string
 	DataLocality      datalocality.DataLocality
+	TopologyKeys      []string
 
 	RunNode       bool
 	RunController bool

--- a/pkg/driver/identityserver.go
+++ b/pkg/driver/identityserver.go
@@ -27,22 +27,34 @@ func (ids *IdentityServer) Probe(ctx context.Context, req *csi.ProbeRequest) (*c
 
 func (ids *IdentityServer) GetPluginCapabilities(ctx context.Context, req *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {
 	glog.V(4).Infof("Using default capabilities")
-	return &csi.GetPluginCapabilitiesResponse{
-		Capabilities: []*csi.PluginCapability{
-			{
-				Type: &csi.PluginCapability_Service_{
-					Service: &csi.PluginCapability_Service{
-						Type: csi.PluginCapability_Service_CONTROLLER_SERVICE,
-					},
-				},
-			},
-			{
-				Type: &csi.PluginCapability_VolumeExpansion_{
-					VolumeExpansion: &csi.PluginCapability_VolumeExpansion{
-						Type: csi.PluginCapability_VolumeExpansion_ONLINE,
-					},
+	capabilities := []*csi.PluginCapability{
+		{
+			Type: &csi.PluginCapability_Service_{
+				Service: &csi.PluginCapability_Service{
+					Type: csi.PluginCapability_Service_CONTROLLER_SERVICE,
 				},
 			},
 		},
+		{
+			Type: &csi.PluginCapability_VolumeExpansion_{
+				VolumeExpansion: &csi.PluginCapability_VolumeExpansion{
+					Type: csi.PluginCapability_VolumeExpansion_ONLINE,
+				},
+			},
+		},
+	}
+
+	if len(ids.Driver.TopologyKeys) > 0 {
+		capabilities = append(capabilities, &csi.PluginCapability{
+			Type: &csi.PluginCapability_Service_{
+				Service: &csi.PluginCapability_Service{
+					Type: csi.PluginCapability_Service_VOLUME_ACCESSIBILITY_CONSTRAINTS,
+				},
+			},
+		})
+	}
+
+	return &csi.GetPluginCapabilitiesResponse{
+		Capabilities: capabilities,
 	}, nil
 }

--- a/pkg/driver/nodeserver.go
+++ b/pkg/driver/nodeserver.go
@@ -32,6 +32,10 @@ type BindMountFn func(source, target string, readOnly bool) error
 // mount. Overridden in tests to simulate a crashed mount.
 type HealthCheckFn func(stagingPath string) bool
 
+// NodeLabelsFn returns the labels of the node the driver runs on. Tests can
+// replace this to avoid real Kubernetes API calls.
+type NodeLabelsFn func(nodeName string) (map[string]string, error)
+
 type NodeServer struct {
 	csi.UnimplementedNodeServer
 
@@ -63,6 +67,7 @@ type NodeServer struct {
 	cleanupStagingFn func(stagingPath string) error
 	unmountFn        func(path string) error
 	bindMountFn      BindMountFn
+	nodeLabelsFn     NodeLabelsFn
 }
 
 var _ = csi.NodeServer(&NodeServer{})
@@ -297,9 +302,46 @@ func (ns *NodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 func (ns *NodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
 	glog.V(3).Infof("node get info, node id: %s", ns.Driver.nodeID)
 
-	return &csi.NodeGetInfoResponse{
+	resp := &csi.NodeGetInfoResponse{
 		NodeId: ns.Driver.nodeID,
-	}, nil
+	}
+
+	segments, err := ns.nodeTopologySegments()
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	if len(segments) > 0 {
+		glog.Infof("node %s accessible topology: %v", ns.Driver.nodeID, segments)
+		resp.AccessibleTopology = &csi.Topology{Segments: segments}
+	}
+
+	return resp, nil
+}
+
+// nodeTopologySegments resolves the configured topology keys to the values
+// they have on this node, so the orchestrator only places volumes on nodes
+// where the driver actually runs.
+func (ns *NodeServer) nodeTopologySegments() (map[string]string, error) {
+	if len(ns.Driver.TopologyKeys) == 0 {
+		return nil, nil
+	}
+
+	labels, err := ns.nodeLabelsFn(ns.Driver.nodeID)
+	if err != nil {
+		return nil, err
+	}
+
+	segments := make(map[string]string, len(ns.Driver.TopologyKeys))
+	for _, key := range ns.Driver.TopologyKeys {
+		value, found := labels[key]
+		if !found {
+			glog.Warningf("node %s has no label %s, skipping it in accessible topology", ns.Driver.nodeID, key)
+			continue
+		}
+		segments[key] = value
+	}
+
+	return segments, nil
 }
 
 func (ns *NodeServer) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {

--- a/pkg/driver/topology_test.go
+++ b/pkg/driver/topology_test.go
@@ -135,6 +135,7 @@ func TestParseTopologyKeys(t *testing.T) {
 		{" , ", nil},
 		{"topology.kubernetes.io/zone", []string{"topology.kubernetes.io/zone"}},
 		{" a , b ,,c ", []string{"a", "b", "c"}},
+		{"kubernetes.io/hostname,topology.kubernetes.io/zone", []string{"kubernetes.io/hostname", "topology.kubernetes.io/zone"}},
 	}
 	for _, test := range tests {
 		if got := ParseTopologyKeys(test.keys); !reflect.DeepEqual(got, test.want) {

--- a/pkg/driver/topology_test.go
+++ b/pkg/driver/topology_test.go
@@ -76,6 +76,34 @@ func TestNodeGetInfoFailsWhenNodeLabelsUnavailable(t *testing.T) {
 	}
 }
 
+func hasAccessibilityConstraints(t *testing.T, keys []string) bool {
+	t.Helper()
+	ids := &IdentityServer{Driver: &SeaweedFsDriver{TopologyKeys: keys}}
+
+	resp, err := ids.GetPluginCapabilities(context.Background(), &csi.GetPluginCapabilitiesRequest{})
+	if err != nil {
+		t.Fatalf("GetPluginCapabilities: %v", err)
+	}
+	for _, capability := range resp.GetCapabilities() {
+		if capability.GetService().GetType() == csi.PluginCapability_Service_VOLUME_ACCESSIBILITY_CONSTRAINTS {
+			return true
+		}
+	}
+	return false
+}
+
+func TestGetPluginCapabilitiesWithTopologyKeys(t *testing.T) {
+	if !hasAccessibilityConstraints(t, []string{"topology.kubernetes.io/zone"}) {
+		t.Error("expected VOLUME_ACCESSIBILITY_CONSTRAINTS to be advertised when topology keys are configured")
+	}
+}
+
+func TestGetPluginCapabilitiesWithoutTopologyKeys(t *testing.T) {
+	if hasAccessibilityConstraints(t, nil) {
+		t.Error("expected VOLUME_ACCESSIBILITY_CONSTRAINTS not to be advertised without topology keys")
+	}
+}
+
 func TestParseTopologyKeys(t *testing.T) {
 	tests := []struct {
 		keys string

--- a/pkg/driver/topology_test.go
+++ b/pkg/driver/topology_test.go
@@ -104,6 +104,28 @@ func TestGetPluginCapabilitiesWithoutTopologyKeys(t *testing.T) {
 	}
 }
 
+func TestAccessibleTopology(t *testing.T) {
+	zoneA := &csi.Topology{Segments: map[string]string{"topology.kubernetes.io/zone": "zone-a"}}
+	zoneB := &csi.Topology{Segments: map[string]string{"topology.kubernetes.io/zone": "zone-b"}}
+
+	if got := accessibleTopology(nil); got != nil {
+		t.Errorf("accessibleTopology(nil) = %v, want nil", got)
+	}
+
+	requisite := &csi.TopologyRequirement{
+		Requisite: []*csi.Topology{zoneA, zoneB},
+		Preferred: []*csi.Topology{zoneB},
+	}
+	if got := accessibleTopology(requisite); !reflect.DeepEqual(got, requisite.Requisite) {
+		t.Errorf("accessibleTopology = %v, want all requisite segments %v", got, requisite.Requisite)
+	}
+
+	preferredOnly := &csi.TopologyRequirement{Preferred: []*csi.Topology{zoneA}}
+	if got := accessibleTopology(preferredOnly); !reflect.DeepEqual(got, preferredOnly.Preferred) {
+		t.Errorf("accessibleTopology = %v, want %v", got, preferredOnly.Preferred)
+	}
+}
+
 func TestParseTopologyKeys(t *testing.T) {
 	tests := []struct {
 		keys string

--- a/pkg/driver/topology_test.go
+++ b/pkg/driver/topology_test.go
@@ -1,0 +1,94 @@
+package driver
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+)
+
+func newTopologyNodeServer(nodeID string, keys []string, labels map[string]string, err error) *NodeServer {
+	return &NodeServer{
+		Driver: &SeaweedFsDriver{nodeID: nodeID, TopologyKeys: keys},
+		nodeLabelsFn: func(string) (map[string]string, error) {
+			return labels, err
+		},
+	}
+}
+
+func TestNodeGetInfoWithoutTopologyKeys(t *testing.T) {
+	ns := newTopologyNodeServer("node-1", nil, map[string]string{"topology.kubernetes.io/zone": "zone-a"}, nil)
+
+	resp, err := ns.NodeGetInfo(context.Background(), &csi.NodeGetInfoRequest{})
+	if err != nil {
+		t.Fatalf("NodeGetInfo: %v", err)
+	}
+	if resp.GetNodeId() != "node-1" {
+		t.Errorf("node id = %q, want %q", resp.GetNodeId(), "node-1")
+	}
+	if resp.GetAccessibleTopology() != nil {
+		t.Errorf("accessible topology = %v, want nil", resp.GetAccessibleTopology())
+	}
+}
+
+func TestNodeGetInfoReportsConfiguredNodeLabels(t *testing.T) {
+	ns := newTopologyNodeServer("node-1", []string{"topology.kubernetes.io/zone", "seaweedfs-csi"}, map[string]string{
+		"topology.kubernetes.io/zone":   "zone-a",
+		"topology.kubernetes.io/region": "region-1",
+		"seaweedfs-csi":                 "true",
+	}, nil)
+
+	resp, err := ns.NodeGetInfo(context.Background(), &csi.NodeGetInfoRequest{})
+	if err != nil {
+		t.Fatalf("NodeGetInfo: %v", err)
+	}
+	want := map[string]string{
+		"topology.kubernetes.io/zone": "zone-a",
+		"seaweedfs-csi":               "true",
+	}
+	if got := resp.GetAccessibleTopology().GetSegments(); !reflect.DeepEqual(got, want) {
+		t.Errorf("segments = %v, want %v", got, want)
+	}
+}
+
+func TestNodeGetInfoSkipsMissingNodeLabels(t *testing.T) {
+	ns := newTopologyNodeServer("node-1", []string{"topology.kubernetes.io/zone", "missing"}, map[string]string{
+		"topology.kubernetes.io/zone": "zone-a",
+	}, nil)
+
+	resp, err := ns.NodeGetInfo(context.Background(), &csi.NodeGetInfoRequest{})
+	if err != nil {
+		t.Fatalf("NodeGetInfo: %v", err)
+	}
+	want := map[string]string{"topology.kubernetes.io/zone": "zone-a"}
+	if got := resp.GetAccessibleTopology().GetSegments(); !reflect.DeepEqual(got, want) {
+		t.Errorf("segments = %v, want %v", got, want)
+	}
+}
+
+func TestNodeGetInfoFailsWhenNodeLabelsUnavailable(t *testing.T) {
+	ns := newTopologyNodeServer("node-1", []string{"topology.kubernetes.io/zone"}, nil, errors.New("api unavailable"))
+
+	if _, err := ns.NodeGetInfo(context.Background(), &csi.NodeGetInfoRequest{}); err == nil {
+		t.Fatal("expected NodeGetInfo to fail when node labels cannot be read")
+	}
+}
+
+func TestParseTopologyKeys(t *testing.T) {
+	tests := []struct {
+		keys string
+		want []string
+	}{
+		{"", nil},
+		{" , ", nil},
+		{"topology.kubernetes.io/zone", []string{"topology.kubernetes.io/zone"}},
+		{" a , b ,,c ", []string{"a", "b", "c"}},
+	}
+	for _, test := range tests {
+		if got := ParseTopologyKeys(test.keys); !reflect.DeepEqual(got, test.want) {
+			t.Errorf("ParseTopologyKeys(%q) = %v, want %v", test.keys, got, test.want)
+		}
+	}
+}

--- a/pkg/driver/utils.go
+++ b/pkg/driver/utils.go
@@ -38,6 +38,7 @@ func NewNodeServer(n *SeaweedFsDriver) *NodeServer {
 		capacityFn: func(volumeID string) (int64, error) {
 			return k8s.GetVolumeCapacity(n.name, volumeID)
 		},
+		nodeLabelsFn:     k8s.GetNodeLabels,
 		isHealthyFn:      isStagingPathHealthy,
 		cleanupStagingFn: cleanupStaleStagingPath,
 		unmountFn:        mountutil.Unmount,
@@ -182,6 +183,17 @@ func (km *KeyMutex) GetMutex(key string) *sync.Mutex {
 
 func (km *KeyMutex) RemoveMutex(key string) {
 	km.mutexes.Delete(key)
+}
+
+// ParseTopologyKeys splits a comma-separated list of node label keys.
+func ParseTopologyKeys(keys string) []string {
+	var parsed []string
+	for _, key := range strings.Split(keys, ",") {
+		if key = strings.TrimSpace(key); key != "" {
+			parsed = append(parsed, key)
+		}
+	}
+	return parsed
 }
 
 func CheckDataLocality(dataLocality *datalocality.DataLocality, dataCenter *string) error {

--- a/pkg/driver/utils.go
+++ b/pkg/driver/utils.go
@@ -188,11 +188,26 @@ func (km *KeyMutex) RemoveMutex(key string) {
 // ParseTopologyKeys splits a comma-separated list of node label keys.
 func ParseTopologyKeys(keys string) []string {
 	var parsed []string
+	prefixes := make(map[string]struct{})
 	for _, key := range strings.Split(keys, ",") {
-		if key = strings.TrimSpace(key); key != "" {
-			parsed = append(parsed, key)
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
 		}
+		parsed = append(parsed, key)
+		prefix, _, found := strings.Cut(key, "/")
+		if !found {
+			prefix = ""
+		}
+		prefixes[prefix] = struct{}{}
 	}
+
+	// The CSI spec wants one identical prefix across all topology keys. Kubernetes
+	// accepts more than one, so warn instead of refusing to start.
+	if len(prefixes) > 1 {
+		glog.Warningf("topology keys %v do not share a single key prefix, which the CSI spec asks for", parsed)
+	}
+
 	return parsed
 }
 

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -92,3 +92,22 @@ func persistentVolumeCapacity(volume *corev1.PersistentVolume) (int64, error) {
 	}
 	return capacity, nil
 }
+
+func GetNodeLabels(nodeName string) (map[string]string, error) {
+	client, err := newInCluster()
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	return getNodeLabels(ctx, client, nodeName)
+}
+
+func getNodeLabels(ctx context.Context, client kubernetes.Interface, nodeName string) (map[string]string, error) {
+	node, err := client.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("get node %q: %w", nodeName, err)
+	}
+	return node.Labels, nil
+}

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -85,6 +85,31 @@ func TestGetVolumeCapacityIgnoresNameCollisionOnFastPath(t *testing.T) {
 	}
 }
 
+func TestGetNodeLabels(t *testing.T) {
+	client := fake.NewSimpleClientset(&corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-1",
+			Labels: map[string]string{"topology.kubernetes.io/zone": "zone-a"},
+		},
+	})
+
+	labels, err := getNodeLabels(context.Background(), client, "node-1")
+	if err != nil {
+		t.Fatalf("getNodeLabels: %v", err)
+	}
+	if got := labels["topology.kubernetes.io/zone"]; got != "zone-a" {
+		t.Fatalf("zone label = %q, want %q", got, "zone-a")
+	}
+}
+
+func TestGetNodeLabelsUnknownNode(t *testing.T) {
+	client := fake.NewSimpleClientset()
+
+	if _, err := getNodeLabels(context.Background(), client, "node-1"); err == nil {
+		t.Fatal("expected an error for an unknown node")
+	}
+}
+
 func newPersistentVolume(name, handle, capacity string) *corev1.PersistentVolume {
 	return &corev1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{Name: name},


### PR DESCRIPTION
Fixes #300.

`NodeGetInfo` returned no `accessible_topology`, so kubelet left `CSINode.spec.drivers[].topologyKeys` `null`. `allowedTopologies` on a SeaweedFS StorageClass was then a no-op: provisioned PVs got no `nodeAffinity`, and pods with SeaweedFS PVCs could be scheduled on nodes without the plugin, hanging in `ContainerCreating` with `CSINode <node> does not contain driver seaweedfs-csi-driver`.

## Changes

* `--topologyKeys=<comma-separated node label keys>` (helm: `topologyKeys`). `NodeGetInfo` looks the keys up in the labels of the node it runs on (via the Kubernetes API, using the node id) and reports them as accessible topology. Keys a node does not have are skipped with a warning. Empty (default) keeps the current behaviour.
* `VOLUME_ACCESSIBILITY_CONSTRAINTS` is advertised only when topology keys are configured, and the chart enables `--feature-gates=Topology=true` on external-provisioner in that case.
* `CreateVolume` echoes the request's topology back as `accessible_topology`, so provisioned PVs get a matching `nodeAffinity`. All requisite segments are returned rather than a single preferred one, because the filer is reachable from every node running the plugin.
* Helm chart passes `--topologyKeys` to both the node and controller components; the node ServiceAccount already has `get` on `nodes`.

## Reproduction / verification

3-node kind cluster, driver restricted to one node (`seaweedfs-csi=true`), StorageClass with `allowedTopologies` on that label.

Before:

```
$ kubectl get csinode csi-topology-worker -o jsonpath='{.spec.drivers}'
[{"name":"seaweedfs-csi-driver","nodeID":"csi-topology-worker","topologyKeys":null}]

$ kubectl get pv <pv> -o jsonpath='{.spec.nodeAffinity}'      # allowedTopologies ignored
(empty)
```

After, with `topologyKeys: [seaweedfs-csi]`:

```
$ kubectl get csinode csi-topology-worker -o jsonpath='{.spec.drivers}'
[{"name":"seaweedfs-csi-driver","nodeID":"csi-topology-worker","topologyKeys":["seaweedfs-csi"]}]

$ kubectl get pv <pv> -o jsonpath='{.spec.nodeAffinity}'
{"required":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"seaweedfs-csi","operator":"In","values":["true"]}]}]}}
```

The test pod is then scheduled only on the node running the driver, mounts and reads/writes normally.

Unit tests cover the node label lookup, the reported segments (including missing labels), the plugin capability and the `CreateVolume` topology.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable node topology support for volume scheduling and accessibility reporting.
  * StorageClasses can use topology constraints through `allowedTopologies`.
  * Configured topology labels are reflected in CSI node information and persistent volume affinity.
  * Added Helm and command-line configuration for topology keys.
  * Missing topology labels are skipped, while label lookup failures are reported clearly.

* **Documentation**
  * Added guidance for topology keys, StorageClass usage, key formatting, and required node-read permissions.

* **Tests**
  * Added coverage for topology reporting, parsing, error handling, capabilities, and volume accessibility selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->