### PR TITLE
Cross-compile the Docker images instead of building them under QEMU

### DIFF
--- a/cmd/seaweedfs-csi-driver/Dockerfile
+++ b/cmd/seaweedfs-csi-driver/Dockerfile
@@ -1,11 +1,21 @@
-FROM golang:1.26-alpine as builder
-
-RUN apk add git g++
+# Stay on the native build platform and cross-compile from there, instead of
+# running the toolchain under QEMU once per target architecture.
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
 
 WORKDIR /go/src/github.com/seaweedfs/seaweedfs-csi-driver
+
+# Downloaded once and shared by all target platforms
+COPY go.mod go.sum ./
+RUN go mod download
+
 COPY . .
 
-RUN go build -ldflags="-s -w" -o /seaweedfs-csi-driver ./cmd/seaweedfs-csi-driver/main.go && go clean -cache -modcache
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ENV CGO_ENABLED=0
+RUN export GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} \
+    && go build -ldflags="-s -w" -o /seaweedfs-csi-driver ./cmd/seaweedfs-csi-driver/main.go
 
 FROM alpine AS final
 RUN apk add fuse

--- a/cmd/seaweedfs-mount/Dockerfile
+++ b/cmd/seaweedfs-mount/Dockerfile
@@ -2,29 +2,43 @@
 # Update via: docker build --build-arg SEAWEEDFS_COMMIT=<hash> ...
 ARG SEAWEEDFS_COMMIT=5e7ab43ddd52
 
-FROM golang:1.26-alpine AS builder
+# Stay on the native build platform and cross-compile from there. Running the
+# toolchain under QEMU for every target architecture is slow and makes the git
+# clone below fail with "cannot pread pack file: Bad address".
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
 
-RUN apk add git g++
+RUN apk add git
 
-# Build weed binary from a specific commit for reproducibility
+# Fetch the weed source at a specific commit for reproducibility. Everything
+# down to the TARGET* args is architecture independent, so it is downloaded
+# once and shared by all target platforms.
 ARG SEAWEEDFS_COMMIT
 RUN git clone https://github.com/seaweedfs/seaweedfs /go/src/github.com/seaweedfs/seaweedfs \
     && cd /go/src/github.com/seaweedfs/seaweedfs \
     && git checkout ${SEAWEEDFS_COMMIT} \
     && cd weed \
-    && go install \
-    && go clean -cache -modcache
+    && go mod download
+
+WORKDIR /go/src/github.com/seaweedfs/seaweedfs-csi-driver
+COPY go.mod go.sum ./
+RUN go mod download
 
 # Build seaweedfs-mount from current context
-WORKDIR /go/src/github.com/seaweedfs/seaweedfs-csi-driver
 COPY . .
 
-RUN go build -ldflags="-s -w" -o /seaweedfs-mount ./cmd/seaweedfs-mount/main.go && go clean -cache -modcache
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ENV CGO_ENABLED=0
+RUN export GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} \
+    && go build -ldflags="-s -w" -o /seaweedfs-mount ./cmd/seaweedfs-mount/main.go \
+    && cd /go/src/github.com/seaweedfs/seaweedfs/weed \
+    && go build -o /weed .
 
 FROM alpine AS final
 RUN apk add fuse
 LABEL author="Chris Lu"
-COPY --from=builder /go/bin/weed /usr/bin/
+COPY --from=builder /weed /usr/bin/
 COPY --from=builder /seaweedfs-mount /
 
 RUN chmod +x /seaweedfs-mount


### PR DESCRIPTION
## Problem

[Run 32935000457](https://github.com/seaweedfs/seaweedfs-csi-driver/actions/runs/32935000457) failed while building the mount-service image. The builder stage clones seaweedfs, and on the QEMU-emulated `linux/arm64` leg git died unpacking the fetched objects:

```
fatal: cannot pread pack file: Bad address
fatal: fetch-pack: invalid index-pack output
ERROR: process "/bin/sh -c git clone https://github.com/seaweedfs/seaweedfs ... && git checkout ${SEAWEEDFS_COMMIT} ..." did not complete successfully: exit code: 128
```

This is a qemu-user bug rather than anything in the change under test, so it can strike any run. Emulation is also why these workflows take so long — recent successful runs are around 2h20m, since the Go toolchain, the clone and the module downloads are all repeated once per architecture under emulation.

## Fix

Pin the builder stage to the native `$BUILDPLATFORM` and cross-compile, taking `GOOS`/`GOARCH`/`GOARM` from `TARGETOS`/`TARGETARCH`/`TARGETVARIANT`. The toolchain then never runs under emulation.

Everything above the `TARGET*` args is architecture independent, so the clone and `go mod download` now run once and are shared by all four target platforms instead of being repeated four times.

Cross-compiling requires `CGO_ENABLED=0`, which also makes the `g++` dependency unnecessary. Upstream seaweedfs builds `weed` with `CGO_ENABLED=0` too; the practical effect is that the binaries use Go's pure-Go DNS resolver.

This covers `versioned_release.yaml` (the failing workflow), `release.yaml`, `dev.yaml` and `integration_test.yaml`, since they all build these two Dockerfiles.

## Verification

- `weed`, `seaweedfs-mount` and `seaweedfs-csi-driver` each cross-compile with `CGO_ENABLED=0` for `linux/amd64`, `linux/arm64`, `linux/arm/v7` and `linux/386`, built against the pinned seaweedfs commit `5e7ab43ddd52`.
- Local buildx runs show the steps executing as `[linux/arm64->386 builder] RUN export GOOS=linux GOARCH=386` and `[linux/arm64->arm/v7 builder] ... GOARM=7`, resolving one `golang` base image instead of four, and the clone that failed in CI completes normally when it is not emulated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved container builds for cross-platform image generation.
  * Streamlined build steps to improve caching and reduce unnecessary tooling.
  * Updated mount images to build and package the required binaries consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->