### PR TITLE
feat: pass extra weed mount arguments from Helm

### DIFF
--- a/cmd/seaweedfs-csi-driver/main.go
+++ b/cmd/seaweedfs-csi-driver/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -17,22 +18,24 @@ var (
 	enableAttacher = flag.Bool("attacher", true, "enable attacher, by default enabled for backward compatibility")
 	driverName     = flag.String("driverName", "seaweedfs-csi-driver", "CSI driver name, used by CSIDriver and StorageClass")
 
-	filer             = flag.String("filer", "localhost:8888", "filer server")
-	endpoint          = flag.String("endpoint", "unix://tmp/seaweedfs-csi.sock", "CSI endpoint to accept gRPC calls")
-	mountEndpoint     = flag.String("mountEndpoint", "unix:///tmp/seaweedfs-mount.sock", "mount service endpoint")
-	nodeID            = flag.String("nodeid", "", "node id")
-	version           = flag.Bool("version", false, "Print the version and exit.")
-	concurrentWriters = flag.Int("concurrentWriters", 128, "limit concurrent goroutine writers if not 0")
-	concurrentReaders = flag.Int("concurrentReaders", 128, "limit concurrent chunk fetches for read operations")
-	cacheCapacityMB   = flag.Int("cacheCapacityMB", 0, "local file chunk cache capacity in MB")
-	cacheMetaTtlSec   = flag.Int("cacheMetaTtlSec", 60, "metadata cache TTL in seconds")
-	cacheDir          = flag.String("cacheDir", os.TempDir(), "local cache directory for file chunks and meta data")
-	uidMap            = flag.String("map.uid", "", "map local uid to uid on filer, comma-separated <local_uid>:<filer_uid>")
-	gidMap            = flag.String("map.gid", "", "map local gid to gid on filer, comma-separated <local_gid>:<filer_gid>")
-	dataCenter        = flag.String("dataCenter", "", "dataCenter this node is running in (locality-definition)")
-	dataLocalityStr   = flag.String("dataLocality", "", "which volume-nodes pods will use for activity (one-of: 'write_preferLocalDc'). Requires used locality-definitions to be set")
-	topologyKeys      = flag.String("topologyKeys", "", "comma-separated node label keys reported as accessible topology, e.g. topology.kubernetes.io/zone")
-	dataLocality      datalocality.DataLocality
+	filer                = flag.String("filer", "localhost:8888", "filer server")
+	endpoint             = flag.String("endpoint", "unix://tmp/seaweedfs-csi.sock", "CSI endpoint to accept gRPC calls")
+	mountEndpoint        = flag.String("mountEndpoint", "unix:///tmp/seaweedfs-mount.sock", "mount service endpoint")
+	nodeID               = flag.String("nodeid", "", "node id")
+	version              = flag.Bool("version", false, "Print the version and exit.")
+	concurrentWriters    = flag.Int("concurrentWriters", 128, "limit concurrent goroutine writers if not 0")
+	mountExtraArgs       = flag.String("mountExtraArgs", "[]", "JSON array of extra weed mount flags, using -name=value or boolean -name")
+	concurrentReaders    = flag.Int("concurrentReaders", 128, "limit concurrent chunk fetches for read operations")
+	cacheCapacityMB      = flag.Int("cacheCapacityMB", 0, "local file chunk cache capacity in MB")
+	cacheMetaTtlSec      = flag.Int("cacheMetaTtlSec", 60, "metadata cache TTL in seconds")
+	cacheDir             = flag.String("cacheDir", os.TempDir(), "local cache directory for file chunks and meta data")
+	uidMap               = flag.String("map.uid", "", "map local uid to uid on filer, comma-separated <local_uid>:<filer_uid>")
+	gidMap               = flag.String("map.gid", "", "map local gid to gid on filer, comma-separated <local_gid>:<filer_gid>")
+	dataCenter           = flag.String("dataCenter", "", "dataCenter this node is running in (locality-definition)")
+	dataLocalityStr      = flag.String("dataLocality", "", "which volume-nodes pods will use for activity (one-of: 'write_preferLocalDc'). Requires used locality-definitions to be set")
+	topologyKeys         = flag.String("topologyKeys", "", "comma-separated node label keys reported as accessible topology, e.g. topology.kubernetes.io/zone")
+	dataLocality         datalocality.DataLocality
+	parsedMountExtraArgs []string
 )
 
 func main() {
@@ -89,6 +92,7 @@ func main() {
 
 	drv.ConcurrentWriters = *concurrentWriters
 	drv.ConcurrentReaders = *concurrentReaders
+	drv.MountExtraArgs = parsedMountExtraArgs
 	drv.CacheCapacityMB = *cacheCapacityMB
 	drv.CacheMetaTtlSec = *cacheMetaTtlSec
 	drv.CacheDir = *cacheDir
@@ -102,6 +106,13 @@ func main() {
 }
 
 func convertRequiredValues() error {
+	if err := json.Unmarshal([]byte(*mountExtraArgs), &parsedMountExtraArgs); err != nil {
+		return fmt.Errorf("invalid mountExtraArgs: %w", err)
+	}
+	if err := driver.ValidateMountArgs(parsedMountExtraArgs); err != nil {
+		return err
+	}
+
 	// Convert DataLocalityStr to DataLocality
 	if *dataLocalityStr != "" {
 		var ok bool

--- a/deploy/helm/seaweedfs-csi-driver/README.md
+++ b/deploy/helm/seaweedfs-csi-driver/README.md
@@ -34,6 +34,19 @@ And running:
 helm install my-seaweedfs-csi-driver seaweedfs-csi-driver/seaweedfs-csi-driver -f seaweedfs-overrides.yaml
 ```
 
+Additional `weed mount` flags can be passed to every volume:
+
+```yaml
+mountExtraArgs:
+  - -debug
+  - -debug.port=6062
+  - -readerCacheSizeMB=256
+  - -memoryLimitMB=768
+```
+
+Arguments managed by the CSI driver, including `-dir`, `-filer`, and
+`-localSocket`, cannot be overridden.
+
 ## Usage
 
 See [Testing](https://github.com/seaweedfs/seaweedfs-csi-driver#testing) on some usage examples.

--- a/deploy/helm/seaweedfs-csi-driver/templates/daemonset.yaml
+++ b/deploy/helm/seaweedfs-csi-driver/templates/daemonset.yaml
@@ -73,6 +73,9 @@ spec:
             {{- with .Values.concurrentReaders }}
             - --concurrentReaders={{ . }}
             {{- end }}
+            {{- with .Values.mountExtraArgs }}
+            - {{ printf "--mountExtraArgs=%s" (toJson .) | quote }}
+            {{- end }}
             {{- with .Values.cacheCapacityMB }}
             - --cacheCapacityMB={{ . }}
             {{- end }}

--- a/deploy/helm/seaweedfs-csi-driver/values.yaml
+++ b/deploy/helm/seaweedfs-csi-driver/values.yaml
@@ -15,6 +15,14 @@ tlsSecret: ""
 #concurrentWriters: 128
 #concurrentReaders: 128
 
+# Extra flags appended to every weed mount command. Arguments managed by the
+# CSI driver, such as -dir and -filer, cannot be overridden here.
+mountExtraArgs: []
+#  - -debug
+#  - -debug.port=6062
+#  - -readerCacheSizeMB=256
+#  - -memoryLimitMB=768
+
 # Security configuration for SeaweedFS security.toml
 # Mounts security.toml to /etc/seaweedfs/security.toml in seaweedfs-mount
 # and csi-seaweedfs-plugin containers, enabling JWT / gRPC / HTTP security.

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -42,6 +42,7 @@ type SeaweedFsDriver struct {
 	grpcDialOption    grpc.DialOption
 	ConcurrentWriters int
 	ConcurrentReaders int
+	MountExtraArgs    []string
 	CacheCapacityMB   int
 	CacheMetaTtlSec   int
 	CacheDir          string

--- a/pkg/driver/mounter.go
+++ b/pkg/driver/mounter.go
@@ -95,6 +95,10 @@ func (u *mountServiceUnmounter) Unmount() error {
 }
 
 func (m *mountServiceMounter) buildMountArgs(targetPath, cacheDir, localSocket string, filers []string) ([]string, error) {
+	if err := ValidateMountArgs(m.driver.MountExtraArgs); err != nil {
+		return nil, err
+	}
+
 	volumeContext := m.volContext
 	if volumeContext == nil {
 		volumeContext = map[string]string{}
@@ -214,7 +218,7 @@ func (m *mountServiceMounter) buildMountArgs(targetPath, cacheDir, localSocket s
 		args = append(args, fmt.Sprintf("-%s=%s", key, value))
 	}
 
-	return args, nil
+	return append(args, m.driver.MountExtraArgs...), nil
 }
 
 func initialCollectionQuotaMB(capacityBytes string) string {
@@ -229,4 +233,18 @@ func initialCollectionQuotaMB(capacityBytes string) string {
 		capacityMB++
 	}
 	return strconv.FormatInt(capacityMB, 10)
+}
+
+func ValidateMountArgs(args []string) error {
+	for _, arg := range args {
+		name, _, _ := strings.Cut(strings.TrimPrefix(arg, "-"), "=")
+		if !strings.HasPrefix(arg, "-") || name == "" || strings.HasPrefix(name, "-") || strings.ContainsAny(name, " \t\r\n") {
+			return fmt.Errorf("invalid mount argument %q: use -name=value or boolean -name", arg)
+		}
+		switch name {
+		case "dir", "dirAutoCreate", "localSocket", "cacheDir", "readOnly", "filer", "filer.path", "collection", "collectionQuotaMB":
+			return fmt.Errorf("mount argument %q is managed by the CSI driver", name)
+		}
+	}
+	return nil
 }

--- a/pkg/driver/mounter_test.go
+++ b/pkg/driver/mounter_test.go
@@ -39,3 +39,29 @@ func TestInitialCollectionQuotaMBDisablesOneByteSentinel(t *testing.T) {
 		t.Fatalf("initialCollectionQuotaMB = %q, want empty", got)
 	}
 }
+
+func TestBuildMountArgsPreservesExtraArgs(t *testing.T) {
+	extra := []string{"-debug", "-debug.port=6062", "-readerCacheSizeMB=256", "-memoryLimitMB=768", "-volumeName=name with spaces"}
+	mounter := &mountServiceMounter{driver: &SeaweedFsDriver{MountExtraArgs: extra}, volumeID: "/buckets/test", readOnly: true}
+	args, err := mounter.buildMountArgs("/staging", "/cache", "/socket", []string{"filer:8888"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(args[len(args)-len(extra):], extra) {
+		t.Fatalf("extra args changed: %v", args)
+	}
+	for _, required := range []string{"-dir=/staging", "-localSocket=/socket", "-readOnly"} {
+		if !slices.Contains(args, required) {
+			t.Errorf("missing %s in %v", required, args)
+		}
+	}
+}
+
+func TestBuildMountArgsRejectsManagedOrPositionalExtraArgs(t *testing.T) {
+	for _, arg := range []string{"", "mount", "--", "-", "-debug.port 6062", "---debug", "-dir=/other", "-readOnly=false", "-filer.path=/other", "-collectionQuotaMB=0"} {
+		mounter := &mountServiceMounter{driver: &SeaweedFsDriver{MountExtraArgs: []string{arg}}, volumeID: "/buckets/test"}
+		if _, err := mounter.buildMountArgs("/staging", "/cache", "/socket", []string{"filer:8888"}); err == nil {
+			t.Errorf("accepted %q", arg)
+		}
+	}
+}


### PR DESCRIPTION
The CSI driver constructs the `weed mount` command internally, which prevents operators from enabling flags such as `-debug` or configuring new mount flags without a driver release.

This adds a `mountExtraArgs` Helm value containing a list of complete `weed mount` arguments. The chart serializes the list as JSON for the node plugin, which appends each item as a distinct process argument. Arguments that control CSI-owned paths, filer identity, read-only mode, or collection identity are rejected so extra arguments cannot break mount management.

Example:

```yaml
mountExtraArgs:
  - -debug
  - -debug.port=6062
  - -readerCacheSizeMB=256
  - -memoryLimitMB=768
```

`-debug` is already supported by SeaweedFS. The reader-cache and runtime-memory flags are introduced by https://github.com/seaweedfs/seaweedfs/pull/11220.

Validation:

- `go test ./pkg/driver -run 'TestBuildMountArgs|TestInitialCollectionQuota' -count=10`
- `go vet ./pkg/driver ./cmd/seaweedfs-csi-driver`
- `helm lint deploy/helm/seaweedfs-csi-driver`
- Rendered the example values and verified one JSON `--mountExtraArgs` node-plugin argument.

The full driver test suite also runs the new tests successfully, but on macOS its existing `TestIsStagingPathHealthy_DoesNotRequireListableDirectory` setup fails because `os.ReadDir` succeeds on a mode-000 temporary directory.