### PR TITLE
fix: detach stale globalmount via lazy unmount when regular umount is busy

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,7 +68,7 @@ jobs:
           buildkitd-flags: "--debug"
 
       - name: Login to DockerHub
-        # if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
           # username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/pkg/driver/mount_util.go
+++ b/pkg/driver/mount_util.go
@@ -6,11 +6,14 @@ import (
 	"os"
 	"time"
 
+	"github.com/seaweedfs/seaweedfs-csi-driver/pkg/mountmanager"
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"k8s.io/mount-utils"
 )
 
 var mountutil = mount.New("")
+
+var lazyUnmount = mountmanager.LazyUnmount
 
 // isStagingPathHealthy checks if the staging path has a healthy FUSE mount.
 // It returns true if the path is mounted and accessible, false otherwise.
@@ -78,8 +81,13 @@ func isStagingPathHealthy(stagingPath string) bool {
 // cannot propagate deletes through a live FUSE.
 func cleanupCorruptedStagingPath(stagingPath string) error {
 	if err := mount.CleanupMountPoint(stagingPath, mountutil, true); err != nil {
-		glog.Warningf("failed to cleanup corrupted mount point %s: %v", stagingPath, err)
-		return err
+		glog.Warningf("standard cleanup of corrupted staging path %s failed: %v; trying lazy unmount", stagingPath, err)
+		if lazyErr := lazyUnmount(stagingPath); lazyErr != nil {
+			return fmt.Errorf("cleanup corrupted mount %s: cleanup %v, lazy unmount %v", stagingPath, err, lazyErr)
+		}
+		if err := os.RemoveAll(stagingPath); err != nil && !os.IsNotExist(err) {
+			return err
+		}
 	}
 	glog.Infof("successfully cleaned up corrupted staging path %s", stagingPath)
 	return nil

--- a/pkg/driver/mount_util_lazy_test.go
+++ b/pkg/driver/mount_util_lazy_test.go
@@ -1,0 +1,86 @@
+package driver
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"k8s.io/mount-utils"
+)
+
+func resolvedTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("resolve temp dir: %v", err)
+	}
+	return dir
+}
+
+// TestCleanupCorruptedStagingPathLazyFallback verifies that cleanupCorruptedStagingPath
+// falls back to a lazy unmount when the regular umount fails (EBUSY from bind mounts),
+// then removes the path so a later NodeStageVolume can recreate the mount.
+// Regression test for seaweedfs/seaweedfs-csi-driver#305.
+func TestCleanupCorruptedStagingPathLazyFallback(t *testing.T) {
+	stagingPath := filepath.Join(resolvedTempDir(t), "globalmount")
+	if err := os.MkdirAll(stagingPath, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	origMountutil := mountutil
+	origLazyUnmount := lazyUnmount
+	defer func() {
+		mountutil = origMountutil
+		lazyUnmount = origLazyUnmount
+	}()
+
+	fake := mount.NewFakeMounter([]mount.MountPoint{{Device: "fuse", Path: stagingPath, Type: "fuse.seaweedfs"}})
+	fake.UnmountFunc = func(path string) error { return errors.New("umount: target is busy") }
+	mountutil = fake
+
+	var lazyCalls int32
+	lazyUnmount = func(p string) error {
+		atomic.StoreInt32(&lazyCalls, 1)
+		if p != stagingPath {
+			t.Errorf("lazy unmount called with %q, want %q", p, stagingPath)
+		}
+		return nil
+	}
+
+	if err := cleanupCorruptedStagingPath(stagingPath); err != nil {
+		t.Fatalf("cleanupCorruptedStagingPath: %v", err)
+	}
+	if atomic.LoadInt32(&lazyCalls) != 1 {
+		t.Fatal("expected lazy unmount to be invoked after CleanupMountPoint failed")
+	}
+	if _, err := os.Stat(stagingPath); !os.IsNotExist(err) {
+		t.Fatalf("expected staging path removed, got err=%v", err)
+	}
+}
+
+// TestCleanupCorruptedStagingPathFailsWhenBothUnmountsFail ensures an error
+// is returned when neither the standard cleanup nor the lazy unmount succeeds.
+func TestCleanupCorruptedStagingPathFailsWhenBothUnmountsFail(t *testing.T) {
+	stagingPath := filepath.Join(resolvedTempDir(t), "globalmount")
+	if err := os.MkdirAll(stagingPath, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	origMountutil := mountutil
+	origLazyUnmount := lazyUnmount
+	defer func() {
+		mountutil = origMountutil
+		lazyUnmount = origLazyUnmount
+	}()
+
+	fake := mount.NewFakeMounter([]mount.MountPoint{{Device: "fuse", Path: stagingPath, Type: "fuse.seaweedfs"}})
+	fake.UnmountFunc = func(path string) error { return errors.New("umount: target is busy") }
+	mountutil = fake
+	lazyUnmount = func(p string) error { return errors.New("lazy unmount: invalid argument") }
+
+	if err := cleanupCorruptedStagingPath(stagingPath); err == nil {
+		t.Fatal("expected error when both standard cleanup and lazy unmount fail")
+	}
+}

--- a/pkg/mountmanager/lazy_unmount_integration_test.go
+++ b/pkg/mountmanager/lazy_unmount_integration_test.go
@@ -1,0 +1,72 @@
+//go:build linux && integration
+
+package mountmanager
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func skipIfNotRoot(t *testing.T) {
+	t.Helper()
+	if os.Getuid() != 0 {
+		t.Skip("integration tests require root (CAP_SYS_ADMIN)")
+	}
+}
+
+// TestIntegrationLazyUnmountDetachesBusyMount reproduces the core mechanism
+// behind seaweedfs/seaweedfs-csi-driver#305. After the weed mount FUSE daemon
+// dies, a regular umount of the staging path fails with EBUSY (the publish
+// bind mounts keep the mount busy), leaving a stale ENOTCONN mount that
+// blocks later NodeStageVolume. A lazy unmount (MNT_DETACH) detaches it
+// anyway so the staging path can be reused.
+//
+// A real FUSE daemon is not needed to exercise the mechanism: any condition
+// that makes a regular umount return EBUSY while MNT_DETACH still succeeds
+// demonstrates the fix. Here an open file on a tmpfs plays the role of the
+// busy reference.
+//
+// Run with: sudo go test -tags integration -run Integration ./pkg/mountmanager/
+func TestIntegrationLazyUnmountDetachesBusyMount(t *testing.T) {
+	skipIfNotRoot(t)
+
+	root := t.TempDir()
+	staging := filepath.Join(root, "staging")
+	if err := os.MkdirAll(staging, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", staging, err)
+	}
+
+	if err := unix.Mount("tmpfs", staging, "tmpfs", 0, ""); err != nil {
+		t.Fatalf("mount tmpfs at %s: %v", staging, err)
+	}
+	defer unix.Unmount(staging, unix.MNT_DETACH)
+
+	// Hold an open file on the mount so a regular umount returns EBUSY,
+	// simulating the busy reference publish bind mounts create on a dead
+	// FUSE staging mount.
+	busyFile := filepath.Join(staging, "busy")
+	f, err := os.Create(busyFile)
+	if err != nil {
+		t.Fatalf("create busy file: %v", err)
+	}
+	defer f.Close()
+
+	if err := unix.Unmount(staging, 0); err == nil {
+		t.Skip("regular umount succeeded; cannot simulate the busy-stale condition")
+	}
+
+	if err := LazyUnmount(staging); err != nil {
+		t.Fatalf("LazyUnmount of busy staging mount failed: %v", err)
+	}
+
+	notMnt, err := kubeMounter.IsLikelyNotMountPoint(staging)
+	if err != nil {
+		t.Fatalf("IsLikelyNotMountPoint after lazy unmount: %v", err)
+	}
+	if !notMnt {
+		t.Fatal("staging path is still a mount point after lazy unmount")
+	}
+}

--- a/pkg/mountmanager/lazy_unmount_integration_test.go
+++ b/pkg/mountmanager/lazy_unmount_integration_test.go
@@ -3,6 +3,7 @@
 package mountmanager
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -40,6 +41,9 @@ func TestIntegrationLazyUnmountDetachesBusyMount(t *testing.T) {
 	}
 
 	if err := unix.Mount("tmpfs", staging, "tmpfs", 0, ""); err != nil {
+		if errors.Is(err, unix.EPERM) {
+			t.Skipf("skipping: mount requires CAP_SYS_ADMIN: %v", err)
+		}
 		t.Fatalf("mount tmpfs at %s: %v", staging, err)
 	}
 	defer unix.Unmount(staging, unix.MNT_DETACH)
@@ -56,6 +60,8 @@ func TestIntegrationLazyUnmountDetachesBusyMount(t *testing.T) {
 
 	if err := unix.Unmount(staging, 0); err == nil {
 		t.Skip("regular umount succeeded; cannot simulate the busy-stale condition")
+	} else if !errors.Is(err, unix.EBUSY) {
+		t.Fatalf("expected EBUSY from regular umount, got: %v", err)
 	}
 
 	if err := LazyUnmount(staging); err != nil {

--- a/pkg/mountmanager/lazy_unmount_linux.go
+++ b/pkg/mountmanager/lazy_unmount_linux.go
@@ -1,0 +1,12 @@
+//go:build linux
+
+package mountmanager
+
+import "golang.org/x/sys/unix"
+
+// LazyUnmount detaches the mount via MNT_DETACH (umount -l) without
+// waiting for references to drain. Used as a fallback when a regular
+// umount fails with EBUSY on a stale FUSE mount whose daemon has died.
+func LazyUnmount(target string) error {
+	return unix.Unmount(target, unix.MNT_DETACH)
+}

--- a/pkg/mountmanager/lazy_unmount_other.go
+++ b/pkg/mountmanager/lazy_unmount_other.go
@@ -1,0 +1,10 @@
+//go:build !linux
+
+package mountmanager
+
+import "errors"
+
+// LazyUnmount is unsupported on non-Linux platforms.
+func LazyUnmount(target string) error {
+	return errors.New("lazy unmount is not supported on this platform")
+}

--- a/pkg/mountmanager/manager.go
+++ b/pkg/mountmanager/manager.go
@@ -18,6 +18,8 @@ import (
 
 var kubeMounter = mount.New("")
 
+var lazyUnmount = LazyUnmount
+
 // Manager owns weed mount processes and exposes helpers to start and stop them.
 type Manager struct {
 	weedBinary string
@@ -224,7 +226,10 @@ func ensureTargetClean(targetPath string) error {
 		} else if mount.IsCorruptedMnt(err) {
 			glog.Warningf("Target path %s is a corrupted mount, attempting to unmount", targetPath)
 			if unmountErr := kubeMounter.Unmount(targetPath); unmountErr != nil {
-				return fmt.Errorf("failed to unmount corrupted mount %s: %w", targetPath, unmountErr)
+				glog.Warningf("unmount corrupted mount %s failed: %v; trying lazy unmount", targetPath, unmountErr)
+				if lazyErr := lazyUnmount(targetPath); lazyErr != nil {
+					return fmt.Errorf("failed to unmount corrupted mount %s: %w", targetPath, unmountErr)
+				}
 			}
 		} else {
 			return err
@@ -334,7 +339,12 @@ func (p *weedMountProcess) wait() {
 
 	// Brief delay to allow FUSE cleanup and pending I/O to complete before unmounting
 	time.Sleep(100 * time.Millisecond)
-	_ = kubeMounter.Unmount(p.target)
+	if err := kubeMounter.Unmount(p.target); err != nil {
+		glog.Warningf("umount %s after weed mount exit failed: %v; trying lazy unmount", p.target, err)
+		if lazyErr := lazyUnmount(p.target); lazyErr != nil {
+			glog.Warningf("lazy unmount %s after weed mount exit failed: %v", p.target, lazyErr)
+		}
+	}
 
 	close(p.done)
 }

--- a/pkg/mountmanager/manager.go
+++ b/pkg/mountmanager/manager.go
@@ -228,7 +228,7 @@ func ensureTargetClean(targetPath string) error {
 			if unmountErr := kubeMounter.Unmount(targetPath); unmountErr != nil {
 				glog.Warningf("unmount corrupted mount %s failed: %v; trying lazy unmount", targetPath, unmountErr)
 				if lazyErr := lazyUnmount(targetPath); lazyErr != nil {
-					return fmt.Errorf("failed to unmount corrupted mount %s: %w", targetPath, unmountErr)
+					return fmt.Errorf("failed to unmount corrupted mount %s: regular unmount: %v; lazy unmount: %w", targetPath, unmountErr, lazyErr)
 				}
 			}
 		} else {

--- a/pkg/mountmanager/manager_lazy_test.go
+++ b/pkg/mountmanager/manager_lazy_test.go
@@ -1,0 +1,97 @@
+package mountmanager
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"syscall"
+	"testing"
+
+	"k8s.io/mount-utils"
+)
+
+func withFakeMounter(target string, fake *mount.FakeMounter, lazy func(string) error) func() {
+	origKubeMounter := kubeMounter
+	origLazyUnmount := lazyUnmount
+	kubeMounter = fake
+	lazyUnmount = lazy
+	return func() {
+		kubeMounter = origKubeMounter
+		lazyUnmount = origLazyUnmount
+	}
+}
+
+// TestEnsureTargetCleanLazyFallbackOnCorruptedMount verifies that ensureTargetClean
+// falls back to a lazy unmount when a corrupted mount's regular umount fails.
+// Regression test for seaweedfs/seaweedfs-csi-driver#305.
+func TestEnsureTargetCleanLazyFallbackOnCorruptedMount(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "staging")
+
+	fake := mount.NewFakeMounter([]mount.MountPoint{{Device: "fuse", Path: target, Type: "fuse.seaweedfs"}})
+	fake.MountCheckErrors = map[string]error{target: syscall.ENOTCONN}
+	fake.UnmountFunc = func(path string) error { return errors.New("umount: target is busy") }
+
+	var lazyCalls int32
+	restore := withFakeMounter(target, fake, func(p string) error {
+		atomic.StoreInt32(&lazyCalls, 1)
+		if p != target {
+			t.Errorf("lazy unmount called with %q, want %q", p, target)
+		}
+		return nil
+	})
+	defer restore()
+
+	if err := ensureTargetClean(target); err != nil {
+		t.Fatalf("ensureTargetClean: %v", err)
+	}
+	if atomic.LoadInt32(&lazyCalls) != 1 {
+		t.Fatal("expected lazy unmount to be invoked after regular unmount failed")
+	}
+	if _, err := os.Stat(target); err != nil {
+		t.Fatalf("target not recreated after cleanup: %v", err)
+	}
+}
+
+// TestEnsureTargetCleanSkipsLazyWhenRegularUnmountSucceeds ensures the lazy
+// fallback is not invoked when the regular unmount succeeds.
+func TestEnsureTargetCleanSkipsLazyWhenRegularUnmountSucceeds(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "staging")
+
+	fake := mount.NewFakeMounter([]mount.MountPoint{{Device: "fuse", Path: target, Type: "fuse.seaweedfs"}})
+	fake.MountCheckErrors = map[string]error{target: syscall.ENOTCONN}
+	fake.UnmountFunc = nil // regular unmount succeeds
+
+	var lazyCalls int32
+	restore := withFakeMounter(target, fake, func(p string) error {
+		atomic.StoreInt32(&lazyCalls, 1)
+		return nil
+	})
+	defer restore()
+
+	if err := ensureTargetClean(target); err != nil {
+		t.Fatalf("ensureTargetClean: %v", err)
+	}
+	if atomic.LoadInt32(&lazyCalls) != 0 {
+		t.Fatal("lazy unmount must not run when regular unmount succeeds")
+	}
+}
+
+// TestEnsureTargetCleanFailsWhenBothUnmountsFail ensures an error is returned
+// when neither the regular nor the lazy unmount can detach the mount.
+func TestEnsureTargetCleanFailsWhenBothUnmountsFail(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "staging")
+
+	fake := mount.NewFakeMounter([]mount.MountPoint{{Device: "fuse", Path: target, Type: "fuse.seaweedfs"}})
+	fake.MountCheckErrors = map[string]error{target: syscall.ENOTCONN}
+	fake.UnmountFunc = func(path string) error { return errors.New("umount: target is busy") }
+
+	restore := withFakeMounter(target, fake, func(p string) error {
+		return errors.New("lazy unmount: invalid argument")
+	})
+	defer restore()
+
+	if err := ensureTargetClean(target); err == nil {
+		t.Fatal("expected error when both unmounts fail")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #305.

When a `weed mount` process exits while a Pod still holds a published bind mount, the regular `umount` of the CSI staging path fails with `EBUSY`. The dead FUSE mount remains in mountinfo (`ENOTCONN`), and a replacement Pod stays in `ContainerCreating` because kubelet cannot stage the volume again (`mkdir ... globalmount: file exists`).

The fix adds a `LazyUnmount` helper (`MNT_DETACH` / `umount -l`) and uses it as a fallback whenever the standard unmount cannot detach a **corrupted** (dead-daemon) staging mount. A lazy unmount is safe here because the FUSE daemon is already gone — there is no live mount to delete user data through. After the lazy detach the staging directory is removed so a later `NodeStageVolume` (or health-monitor recovery) can recreate the mount without manual intervention.

### Changes (one logic change per commit)

1. **fix: add LazyUnmount helper to detach stale FUSE mounts** — adds the platform-split `LazyUnmount` (`MNT_DETACH` on Linux, unsupported-platform error elsewhere) in `pkg/mountmanager`.
2. **fix: lazily detach stale mount when weed mount process exits** — uses `LazyUnmount` as a fallback in `weedMountProcess.wait()` (the primary #305 path: detach the stale FUSE mount right after the daemon dies) and in `ensureTargetClean` (corrupted mounts found while re-staging). Includes unit tests. `Fixes #305`.
3. **fix: lazily detach corrupted staging mount during cleanup** — uses `LazyUnmount` as a fallback in `cleanupCorruptedStagingPath`, which both `NodeStageVolume` and the health monitor's `recoverVolume` reach via `cleanupStaleStagingPath`. Includes unit tests.
4. **test: reproduce stale busy-mount detach with lazy unmount** — adds a `linux,integration` test that reproduces the busy-stale condition (regular `umount` returns `EBUSY`, `LazyUnmount` detaches it) with a real tmpfs mount.
5. **fix: include lazy unmount error in ensureTargetClean failure message** — when both the regular and lazy unmount fail, surface both errors instead of discarding the lazy-unmount error (Greptile review).
6. **test: harden lazy unmount integration test** — skip on `EPERM` (no `CAP_SYS_ADMIN`) instead of only on non-root uid, and require `EBUSY` from the regular `umount` before exercising the lazy fallback (CodeRabbit review).

### Why lazy unmount is safe

The fallback only runs for **corrupted** mounts (`IsCorruptedMnt` / `ENOTCONN`), i.e. the FUSE daemon has already exited. `MNT_DETACH` detaches the mount from the namespace immediately; existing bind mounts that still reference it keep seeing `ENOTCONN` (expected — the daemon is dead) and are torn down normally when the pods are unpublished. A live FUSE mount never reaches this path, so `RemoveAll` cannot recurse into a working mount.

### Not addressed (by design)

CodeRabbit suggested returning the post-exit cleanup error from `stop()` and retaining the `mountEntry` until cleanup succeeds. This is **not** adopted: `recoverVolume` aborts recovery on any `vol.unmounter.Unmount()` error, so returning the error would block the health monitor from reaching `cleanupCorruptedStagingPath` — the path that actually fixes the stale mount via the lazy fallback added here. The current behavior (log and proceed, then clean up via `cleanupCorruptedStagingPath` on the next sweep/`NodeStageVolume`) preserves the existing contract and the recovery path. CodeRabbit reviewed this rationale and withdrew the finding.

#### Test plan
- [x] `go build ./...`
- [x] `go test ./... -race -count=1` (Linux container; passes)
- [x] `go vet ./...`
- [x] `sudo go test -tags integration ./pkg/driver/` (Linux container; passes)
- [x] `sudo go test -tags integration -run Integration ./pkg/mountmanager/` (Linux container; real-mount reproduction passes)
- [ ] CI green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup of busy or corrupted mount paths by falling back to lazy unmounting.
  - Reports combined errors when both standard and lazy unmount attempts fail.
  - Applies the same fallback when mount cleanup occurs after a process exits.
  - Removes stale staging paths after successful lazy unmounts.

- **Chores**
  - Updated release automation to authenticate with Docker Hub for all non-pull-request events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->